### PR TITLE
Support attaching to iisexpress instance.

### DIFF
--- a/LightBlue.MultiHost/MainWindow.xaml.cs
+++ b/LightBlue.MultiHost/MainWindow.xaml.cs
@@ -178,7 +178,14 @@ namespace LightBlue.MultiHost
 
         private void Debug_OnClick(object sender, RoutedEventArgs e)
         {
-            Debugger.Launch();
+            if (SelectedItem != null)
+            {
+                SelectedItem.Debug();
+            }
+            else
+            {
+                Debugger.Launch();
+            }
         }
 
         private void FilterTextBox_OnTextChanged(object sender, TextChangedEventArgs e)

--- a/LightBlue.MultiHost/Runners/IisExpressRunner.cs
+++ b/LightBlue.MultiHost/Runners/IisExpressRunner.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using LightBlue.MultiHost.IISExpress;
 using LightBlue.MultiHost.ViewModel;
@@ -51,6 +53,17 @@ namespace LightBlue.MultiHost.Runners
                 _completed.SetResult(new object());
             }
             _started.SetResult(new object());
+		}
+
+        public bool Debug()
+        {
+            if (File.Exists(@"c:\\windows\\system32\\vsjitdebugger.exe"))
+            {
+                var psi = new ProcessStartInfo(@"c:\\windows\\system32\\vsjitdebugger.exe", "-p " + _process.Id);
+                Process.Start(psi);
+                return true;
+            }
+            return false;
         }
 
         public void Dispose()

--- a/LightBlue.MultiHost/Runners/RoleRunner.cs
+++ b/LightBlue.MultiHost/Runners/RoleRunner.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading.Tasks;
 using LightBlue.MultiHost.ViewModel;
 
@@ -45,8 +47,6 @@ namespace LightBlue.MultiHost.Runners
 
         public void Start()
         {
-
-
             if (IsWebSite())
             {
                 var website = RunnerFactory.CreateForWebSite(_role);
@@ -70,6 +70,19 @@ namespace LightBlue.MultiHost.Runners
             {
                 r.Dispose();
             }
+        }
+
+        public void Debug()
+        {
+            if (IsWebSite())
+            {
+                if (_resources.OfType<IisExpressRunner>().First().Debug())
+                {
+                    return;
+                }
+            }
+
+            Debugger.Launch();
         }
     }
 }

--- a/LightBlue.MultiHost/ViewModel/Role.cs
+++ b/LightBlue.MultiHost/ViewModel/Role.cs
@@ -215,5 +215,17 @@ namespace LightBlue.MultiHost.ViewModel
                 _dispatcher.Invoke(a);
             }
         }
+
+        public void Debug()
+        {
+            if (_current != null)
+            {
+                _current.Debug();
+            }
+            else
+            {
+                Debugger.Launch();
+            }
+        }
     }
 }


### PR DESCRIPTION
Use vsjitdebugger (if available) to attach the debugger to an IISExpress process.

NB - important to remember to check the box shown here, else you'll only attach to native code.

![image](https://cloud.githubusercontent.com/assets/160201/8793643/815281c4-2fac-11e5-9d2e-8d7163b33afb.png)
