### PR TITLE
Role logger improvements

### DIFF
--- a/LightBlue.MultiHost/Infrastructure/Controls/FifoLog.cs
+++ b/LightBlue.MultiHost/Infrastructure/Controls/FifoLog.cs
@@ -26,8 +26,12 @@ namespace LightBlue.MultiHost.Infrastructure.Controls
         public FifoLog(int maxLines)
         {
             _maxLines = maxLines;
-            _timer = new DispatcherTimer(TimeSpan.FromMilliseconds(500), DispatcherPriority.Normal, OnDumpText, Dispatcher);
-            Loaded += (s, a) => { _textBox.ScrollToEnd(); _timer.Start(); };
+            _timer = new DispatcherTimer(TimeSpan.FromMilliseconds(500), DispatcherPriority.Normal, OnTimerTick, Dispatcher);
+            Loaded += (s, a) =>
+            {
+                DumpText();
+                _timer.Start();
+            };
             Unloaded += (s, a) => _timer.Stop();
         }
 
@@ -60,7 +64,12 @@ namespace LightBlue.MultiHost.Infrastructure.Controls
             _needsDump = true;
         }
 
-        private void OnDumpText(object sender, EventArgs e)
+        private void OnTimerTick(object sender, EventArgs e)
+        {
+            DumpText();
+        }
+
+        private void DumpText()
         {
             if (_textBox == null)
             {

--- a/LightBlue.MultiHost/MainWindow.xaml
+++ b/LightBlue.MultiHost/MainWindow.xaml
@@ -1,9 +1,18 @@
 ﻿<Window x:Class="LightBlue.MultiHost.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:LightBlue.MultiHost.Infrastructure.Controls"
+        xmlns:componentModel="clr-namespace:System.ComponentModel;assembly=WindowsBase"
         Title = "{Binding Version, StringFormat=Steel Blue {0}}" Height="720" Width="1280"
         Icon="{Binding MainIcon}">
+    
+    <Window.Resources>
+        <CollectionViewSource x:Key="Roles" Source="{Binding SelectedItem.Logs}">
+            <CollectionViewSource.SortDescriptions>
+                <componentModel:SortDescription PropertyName="Key" />
+            </CollectionViewSource.SortDescriptions>
+        </CollectionViewSource>
+    </Window.Resources>
+    
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto"/>
@@ -45,8 +54,8 @@
         </ListView>
         
         <GridSplitter Grid.Column="1" Grid.RowSpan="2" Width="5" HorizontalAlignment="Stretch" />
-        
-        <ItemsControl ItemsSource="{Binding SelectedItem.Logs}" Grid.Column="2" Grid.Row="0" Grid.RowSpan="2">
+
+        <ItemsControl ItemsSource="{Binding Source={StaticResource Roles}}" Grid.Column="2" Grid.Row="0" Grid.RowSpan="2">
             <ItemsControl.ItemsPanel>
                 <ItemsPanelTemplate>
                     <UniformGrid Columns="1"/>


### PR DESCRIPTION
Order the loggers by key (without this, first logger to log is at the top, and it may be different between web-roles).

Fifo-logger had a slight delay (caused by dispatcher timer not ticking immediately) when loaded. Immediately call DumpText when loaded now to ensure we don't get the delay.
