### PR TITLE
UndoLimit = 0

### DIFF
--- a/LightBlue.MultiHost/Infrastructure/Controls/FifoLog.cs
+++ b/LightBlue.MultiHost/Infrastructure/Controls/FifoLog.cs
@@ -39,6 +39,7 @@ namespace LightBlue.MultiHost.Infrastructure.Controls
         {
             base.OnApplyTemplate();
             _textBox = (TextBox)GetTemplateChild(TextBoxTemplatePart);
+            _textBox.UndoLimit = 0;
         }
 
         public void Write(string logItem)


### PR DESCRIPTION
By setting this to 0, we stop 100 x (default value) text changes being tracked by WPF
