### PR TITLE
Add a border to the MainWindow. Because UX.

### DIFF
--- a/LightBlue.MultiHost/MainWindow.xaml
+++ b/LightBlue.MultiHost/MainWindow.xaml
@@ -4,6 +4,7 @@
         xmlns:componentModel="clr-namespace:System.ComponentModel;assembly=WindowsBase"
         xmlns:controls="http://metro.mahapps.com/winfx/xaml/controls"
         Title = "{Binding Version, StringFormat=LightBlue {0}}" Height="720" Width="1280"
+        GlowBrush="{DynamicResource AccentColorBrush}"
         Icon="{Binding MainIcon}">
 
     <Window.Resources>


### PR DESCRIPTION
Before:
![image](https://cloud.githubusercontent.com/assets/5119141/8947156/174351a4-35ca-11e5-9bc6-15d4bd0db477.png)

After:
![image](https://cloud.githubusercontent.com/assets/5119141/8947112/8c09640c-35c9-11e5-838f-447279ac3de4.png)

Alternatively, we can go with a simple grey border.
