### PR TITLE
Feature pack

### DIFF
--- a/LightBlue.MultiHost/Controls/FifoLog.cs
+++ b/LightBlue.MultiHost/Controls/FifoLog.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -8,15 +7,18 @@ using System.Windows.Threading;
 
 namespace LightBlue.MultiHost.Controls
 {
+    [TemplatePart(Name = HeaderPart, Type = typeof(Label))]
     [TemplatePart(Name = TextBoxTemplatePart, Type = typeof(TextBox))]
     public class FifoLog : Control
     {
+        public string LogName { get; private set; }
         private readonly int _maxLines;
         private readonly object _bufferLock = new object();
         private readonly LinkedList<string> _internalBuffer = new LinkedList<string>(new[] { string.Empty });
         private readonly DispatcherTimer _timer;
         private bool _needsDump;
         private TextBox _textBox;
+        private const string HeaderPart = "PART_HeaderDisplayer";
         private const string TextBoxTemplatePart = "PART_LogContentDisplayer";
         private DateTime _selectionTime;
 
@@ -25,8 +27,9 @@ namespace LightBlue.MultiHost.Controls
             DefaultStyleKeyProperty.OverrideMetadata(typeof(FifoLog), new FrameworkPropertyMetadata(typeof(FifoLog)));
         }
 
-        public FifoLog(int maxLines)
+        public FifoLog(string name, int maxLines)
         {
+            LogName = name;
             _maxLines = maxLines;
             _timer = new DispatcherTimer(TimeSpan.FromMilliseconds(500), DispatcherPriority.Normal, OnTimerTick, Dispatcher);
             _timer.Stop();
@@ -35,6 +38,10 @@ namespace LightBlue.MultiHost.Controls
         public override void OnApplyTemplate()
         {
             base.OnApplyTemplate();
+
+            var label = (Label)GetTemplateChild(HeaderPart);
+            label.Content = LogName;
+
             _textBox = (TextBox)GetTemplateChild(TextBoxTemplatePart);
             _textBox.UndoLimit = 0;
             _textBox.SelectionChanged += TextWasSelected;

--- a/LightBlue.MultiHost/Controls/Notification.xaml
+++ b/LightBlue.MultiHost/Controls/Notification.xaml
@@ -1,0 +1,91 @@
+﻿<UserControl x:Class="LightBlue.MultiHost.Controls.Notification"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             mc:Ignorable="d" 
+             d:DesignHeight="100" d:DesignWidth="400"
+             Height="100" Width="400" Padding="5">
+
+    <FrameworkElement.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/Resources/Icons.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </FrameworkElement.Resources>
+
+    <VisualStateManager.VisualStateGroups>
+        <VisualStateGroup Name="TransitionGroups">
+            <VisualState Name="Disappear">
+                <Storyboard Completed="Disappeared">
+                    <DoubleAnimation To="0.0"
+                          Storyboard.TargetName="NotificationBorder" 
+                          Storyboard.TargetProperty="Opacity"/>
+                </Storyboard>
+            </VisualState>
+            <VisualStateGroup.Transitions>
+                <VisualTransition To="Disappear" GeneratedDuration="00:00:00.5">
+                    <VisualTransition.GeneratedEasingFunction>
+                        <ExponentialEase EasingMode="EaseOut" Exponent="10"/>
+                    </VisualTransition.GeneratedEasingFunction>
+                </VisualTransition>
+            </VisualStateGroup.Transitions>
+        </VisualStateGroup>
+        <VisualStateGroup Name="MouseStates">
+            <VisualState Name="MouseEnter">
+                <Storyboard>
+                    <DoubleAnimation To="1" 
+                          Storyboard.TargetName="NotificationBorder" 
+                          Storyboard.TargetProperty="Opacity"/>
+                    <ColorAnimation To="Black" 
+                          Storyboard.TargetName="NotificationBackgroundBrush" 
+                          Storyboard.TargetProperty="Color"/>
+                </Storyboard>
+            </VisualState>
+            <VisualState Name="MouseLeave" />
+            <VisualStateGroup.Transitions>
+                <VisualTransition To="MouseLeave" GeneratedDuration="00:00:00"/>
+                <VisualTransition To="MouseEnter" GeneratedDuration="00:00:00.5">
+                    <VisualTransition.GeneratedEasingFunction>
+                        <ExponentialEase EasingMode="EaseOut" Exponent="10"/>
+                    </VisualTransition.GeneratedEasingFunction>
+                </VisualTransition>
+            </VisualStateGroup.Transitions>
+        </VisualStateGroup>
+    </VisualStateManager.VisualStateGroups>
+
+    <Border x:Name="NotificationBorder" Opacity="0.7" CornerRadius="15" BorderThickness="2" BorderBrush="White" >
+        <Border.Background>
+            <SolidColorBrush x:Name="NotificationBackgroundBrush" Color="#222222"></SolidColorBrush>
+        </Border.Background>
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"></ColumnDefinition>
+                <ColumnDefinition Width="8*"></ColumnDefinition>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*"></RowDefinition>
+                <RowDefinition Height="2*"></RowDefinition>
+            </Grid.RowDefinitions>
+
+            <Button x:Name="dismissButton" Background="Transparent" BorderBrush="Transparent" 
+                    Grid.Row="0" Grid.Column="0" Height="20" Width="20" HorizontalAlignment="Left" 
+                    VerticalAlignment="Top" Margin="5">
+                <Button.Content>
+                    <Rectangle Fill="White" Height="10" Width="10">
+                        <Rectangle.OpacityMask>
+                            <VisualBrush  Visual="{StaticResource appbar_close}" />
+                        </Rectangle.OpacityMask>
+                    </Rectangle>
+                </Button.Content>
+            </Button>
+
+            <TextBlock Grid.Row="0" Grid.Column="1" Margin="5">
+                <Hyperlink x:Name="titleText" Foreground="Yellow" FontFamily="Consolas" FontSize="14" ></Hyperlink>
+            </TextBlock>
+            <TextBlock Grid.Row="1" Grid.Column="1" Foreground="White" FontFamily="Consolas" Margin="5"  Text="Notification Content" x:Name="contentText"></TextBlock>
+        </Grid>
+    </Border>
+
+</UserControl>

--- a/LightBlue.MultiHost/Controls/Notification.xaml.cs
+++ b/LightBlue.MultiHost/Controls/Notification.xaml.cs
@@ -11,14 +11,29 @@ namespace LightBlue.MultiHost.Controls
     public partial class Notification
     {
         private readonly TaskCompletionSource<object> _removeTask;
+        private bool _isDisappearing;
 
         public Notification()
         {
             InitializeComponent();
+
+            Loaded += AddHandlers;
+            Unloaded += RemoveHandlers;
+            _removeTask = new TaskCompletionSource<object>();
+        }
+
+        private void AddHandlers(object sender, RoutedEventArgs e)
+        {
             MouseLeave += OnMouseLeave;
             MouseEnter += OnMouseEnter;
-            _removeTask = new TaskCompletionSource<object>();
             PreviewMouseUp += OnMakeVisible;
+        }
+
+        private void RemoveHandlers(object sender, RoutedEventArgs e)
+        {
+            MouseLeave -= OnMouseLeave;
+            MouseEnter -= OnMouseEnter;
+            PreviewMouseUp -= OnMakeVisible;
         }
 
         private void OnMakeVisible(object sender, MouseButtonEventArgs e)
@@ -32,16 +47,19 @@ namespace LightBlue.MultiHost.Controls
 
         private void OnMouseEnter(object sender, MouseEventArgs e)
         {
+            if (_isDisappearing) return;
             VisualStateManager.GoToElementState(this, "MouseEnter", true);
         }
 
         private void OnMouseLeave(object sender, MouseEventArgs e)
         {
+            if (_isDisappearing) return;
             VisualStateManager.GoToElementState(this, "MouseLeave", true);
         }
 
         public Task Disappear()
         {
+            _isDisappearing = true;
             VisualStateManager.GoToElementState(this, "Disappear", true);
             return _removeTask.Task;
         }

--- a/LightBlue.MultiHost/Controls/Notification.xaml.cs
+++ b/LightBlue.MultiHost/Controls/Notification.xaml.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Input;
+
+namespace LightBlue.MultiHost.Controls
+{
+    /// <summary>
+    ///     Interaction logic for Notification.xaml
+    /// </summary>
+    public partial class Notification
+    {
+        private readonly TaskCompletionSource<object> _removeTask;
+
+        public Notification()
+        {
+            InitializeComponent();
+            MouseLeave += OnMouseLeave;
+            MouseEnter += OnMouseEnter;
+            _removeTask = new TaskCompletionSource<object>();
+            PreviewMouseUp += OnMakeVisible;
+        }
+
+        private void OnMakeVisible(object sender, MouseButtonEventArgs e)
+        {
+            var mainWindow = App.Current.MainWindow;
+            if (mainWindow.WindowState == WindowState.Minimized)
+            {
+                mainWindow.WindowState = WindowState.Normal;
+            }
+        }
+
+        private void OnMouseEnter(object sender, MouseEventArgs e)
+        {
+            VisualStateManager.GoToElementState(this, "MouseEnter", true);
+        }
+
+        private void OnMouseLeave(object sender, MouseEventArgs e)
+        {
+            VisualStateManager.GoToElementState(this, "MouseLeave", true);
+        }
+
+        public Task Disappear()
+        {
+            VisualStateManager.GoToElementState(this, "Disappear", true);
+            return _removeTask.Task;
+        }
+
+        private void Disappeared(object sender, EventArgs e)
+        {
+            _removeTask.TrySetResult(null);
+        }
+    }
+}

--- a/LightBlue.MultiHost/Controls/NotificationAdorner.cs
+++ b/LightBlue.MultiHost/Controls/NotificationAdorner.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Diagnostics;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Documents;
+using System.Windows.Media;
+
+namespace LightBlue.MultiHost.Controls
+{
+    class NotificationAdorner : Adorner
+    {
+        private Control _child;
+
+        public NotificationAdorner(UIElement adornedElement)
+            : base(adornedElement)
+        {
+        }
+
+        protected override int VisualChildrenCount
+        {
+            get
+            {
+                return 1;
+            }
+        }
+
+        protected override Visual GetVisualChild(int index)
+        {
+            if (index != 0) throw new ArgumentOutOfRangeException();
+            return _child;
+        }
+
+        public Control Child
+        {
+            get { return _child; }
+            set
+            {
+                if (_child != null)
+                {
+                    RemoveVisualChild(_child);
+                }
+                _child = value;
+                if (_child != null)
+                {
+                    AddVisualChild(_child);
+                }
+            }
+        }
+
+        protected override Size MeasureOverride(Size constraint)
+        {
+            _child.Measure(constraint);
+            return constraint;
+        }
+
+        protected override Size ArrangeOverride(Size finalSize)
+        {
+            var location = new Point(finalSize.Width - _child.DesiredSize.Width, 0);
+            var finalRect = new Rect(location, _child.DesiredSize);
+
+            _child.Arrange(finalRect);
+            Trace.WriteLine("Measure - " + finalRect );
+
+            return finalSize;
+        }
+    }
+}

--- a/LightBlue.MultiHost/Controls/NotificationHub.cs
+++ b/LightBlue.MultiHost/Controls/NotificationHub.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Threading;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Threading;
+
+namespace LightBlue.MultiHost.Controls
+{
+    public static class NotificationHub
+    {
+        private static readonly ObservableCollection<Notification> Notifications = new ObservableCollection<Notification>();
+        private static Dispatcher _dispatcher;
+        private static Popup _notificationWindow;
+        private static DispatcherTimer _adornerRemoveTimer;
+
+        public static void Initialise(Window owner)
+        {
+            _dispatcher = owner.Dispatcher;
+            _notificationWindow = new Popup()
+            {
+                Child = new ItemsControl
+                {
+                    ItemsSource = Notifications
+                },
+                Placement = PlacementMode.Custom,
+                AllowsTransparency = true,
+                IsOpen = true
+            };
+
+            _notificationWindow.CustomPopupPlacementCallback += PlacePopup;
+
+            _adornerRemoveTimer = new DispatcherTimer(DispatcherPriority.Normal, owner.Dispatcher)
+            {
+                Interval = TimeSpan.FromSeconds(1),
+                IsEnabled = true
+            };
+            _adornerRemoveTimer.Tick += ClearAdorners;
+
+        }
+
+        private static CustomPopupPlacement[] PlacePopup(Size popupsize, Size targetsize, Point offset)
+        {
+            return new[]
+            {
+                new CustomPopupPlacement(new Point(SystemParameters.FullPrimaryScreenWidth - popupsize.Width, 0),
+                    PopupPrimaryAxis.None),
+            };
+        }
+
+        private static void ClearAdorners(object sender, EventArgs e)
+        {
+            var toRemove = new List<Notification>();
+            foreach (var adorner in Notifications)
+            {
+                if (adorner.IsMouseOver)
+                {
+                    adorner.Tag = TimeSpan.FromSeconds(5);
+                }
+                else
+                {
+                    var ttl = TimeSpan.FromSeconds(((TimeSpan) adorner.Tag).TotalSeconds - 1);
+                    if (ttl <= TimeSpan.Zero && !adorner.IsMouseOver)
+                    {
+                        toRemove.Add(adorner);
+                    }
+                    adorner.Tag = ttl;
+                }
+            }
+            foreach (var adorner in toRemove)
+            {
+                RemoveAdorner(adorner);
+            }
+        }
+
+        private static async void RemoveAdorner(Notification adorner)
+        {
+            await adorner.Disappear();
+            Notifications.Remove(adorner);
+        }
+
+        public static void Notify(string title, string content, Action onclick)
+        {
+            EnsureUiThread(() =>
+            {
+                var notification = new Notification
+                {
+                    titleText = { Command = new DelegateCommand(onclick) },
+                    contentText = { Text = content },
+                    Tag = TimeSpan.FromSeconds(5),
+                };
+                notification.titleText.Inlines.Add(title);
+                notification.MouseUp += (s, a) => onclick();
+                notification.dismissButton.Click += (s, a) => RemoveAdorner(notification);
+                Notifications.Add(notification);
+
+            });
+        }
+
+        private static void EnsureUiThread(Action a)
+        {
+            if (_dispatcher.CheckAccess())
+            {
+                a();
+                return;
+            }
+            _dispatcher.Invoke(a);
+        }
+
+        private class DelegateCommand : ICommand
+        {
+            private readonly Action _onclick;
+
+            public DelegateCommand(Action onclick)
+            {
+                _onclick = onclick;
+                var warnAsError = CanExecuteChanged;
+            }
+
+            public bool CanExecute(object parameter)
+            {
+                return true;
+            }
+
+            public void Execute(object parameter)
+            {
+                _onclick();
+            }
+
+            public event EventHandler CanExecuteChanged;
+        }
+    }
+}

--- a/LightBlue.MultiHost/LightBlue.MultiHost.csproj
+++ b/LightBlue.MultiHost/LightBlue.MultiHost.csproj
@@ -92,6 +92,7 @@
     <Compile Include="IISExpress\WebHostArgs.cs" />
     <Compile Include="IOpenFileDialogService.cs" />
     <Compile Include="Configuration\MultiHostConfigurationService.cs" />
+    <Compile Include="ListCollectionViewEx.cs" />
     <Compile Include="OpenFileDialogService.cs" />
     <Compile Include="Configuration\RoleConfigurationService.cs" />
     <Compile Include="ViewModel\EditRole.cs" />

--- a/LightBlue.MultiHost/LightBlue.MultiHost.csproj
+++ b/LightBlue.MultiHost/LightBlue.MultiHost.csproj
@@ -81,6 +81,11 @@
     </ApplicationDefinition>
     <Compile Include="Configuration\MultiHostConfiguration.cs" />
     <Compile Include="Controls\FifoLog.cs" />
+    <Compile Include="Controls\Notification.xaml.cs">
+      <DependentUpon>Notification.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Controls\NotificationAdorner.cs" />
+    <Compile Include="Controls\NotificationHub.cs" />
     <Compile Include="EnumToItemsSource.cs" />
     <Compile Include="IISExpress\IisExpressHelper.cs" />
     <Compile Include="IISExpress\WebConfigHelper.cs" />
@@ -114,6 +119,10 @@
     <Compile Include="ViewModel\RoleStates\Starting.cs" />
     <Compile Include="ViewModel\RoleStates\Stopped.cs" />
     <Compile Include="ViewModel\RoleStates\Stopping.cs" />
+    <Page Include="Controls\Notification.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/LightBlue.MultiHost/ListCollectionViewEx.cs
+++ b/LightBlue.MultiHost/ListCollectionViewEx.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections;
+using System.Collections.Specialized;
+using System.Windows;
+using System.Windows.Data;
+
+namespace LightBlue.MultiHost
+{
+    public class ListCollectionViewEx : ListCollectionView, IWeakEventListener
+    {
+        public ListCollectionViewEx(IList list) : base(list)
+        {
+            var changed = list as INotifyCollectionChanged;
+            if (changed != null)
+            {
+                changed.CollectionChanged -= OnCollectionChanged;
+                CollectionChangedEventManager.AddListener(changed, this);
+            }
+        }
+
+        public bool ReceiveWeakEvent(Type managerType, object sender, EventArgs e)
+        {
+            if (!(e is NotifyCollectionChangedEventArgs)) return false;
+            OnCollectionChanged(sender, (e as NotifyCollectionChangedEventArgs));
+            return true;
+        }
+    }
+}

--- a/LightBlue.MultiHost/MainWindow.xaml
+++ b/LightBlue.MultiHost/MainWindow.xaml
@@ -122,19 +122,6 @@
                     <UniformGrid Columns="1"/>
                 </ItemsPanelTemplate>
             </ItemsControl.ItemsPanel>
-            <ItemsControl.ItemTemplate>
-                <DataTemplate>
-                    <TextBlock>BOO</TextBlock>
-                    <!--<Grid Margin="5">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="*"/>
-                        </Grid.RowDefinitions>
-                        <TextBlock Margin="0 0 0 2" FontSize="14" FontFamily="Consolas" Text="Boogallo"/>
-                        --><!--<ContentControl Grid.Row="1" Content="{Binding}" />--><!--
-                    </Grid>-->
-                </DataTemplate>
-            </ItemsControl.ItemTemplate>
         </ItemsControl>
 
     </Grid>

--- a/LightBlue.MultiHost/MainWindow.xaml
+++ b/LightBlue.MultiHost/MainWindow.xaml
@@ -11,7 +11,7 @@
         <ResourceDictionary>
             <CollectionViewSource x:Key="Roles" Source="{Binding SelectedItem.Logs}">
                 <CollectionViewSource.SortDescriptions>
-                    <componentModel:SortDescription PropertyName="Key" />
+                    <componentModel:SortDescription PropertyName="LogName" />
                 </CollectionViewSource.SortDescriptions>
             </CollectionViewSource>
             <ResourceDictionary.MergedDictionaries>
@@ -93,7 +93,7 @@
         </StackPanel>
 
         <ListView Grid.IsSharedSizeScope="True" Background="White" x:Name="listView" Margin="2" Grid.Column="0" Grid.Row="2" 
-                  BorderThickness="0" ItemsSource="{Binding CollectionViewSource.View}" SelectedItem="{Binding SelectedItem}"
+                  BorderThickness="0" ItemsSource="{Binding CollectionViewSource}" SelectedItem="{Binding SelectedItem}"
                   VirtualizingStackPanel.IsVirtualizing="False">
             <ListView.ItemTemplate>
                 <DataTemplate>
@@ -114,7 +114,9 @@
 
         <GridSplitter Grid.Column="1" Grid.RowSpan="3" Width="5" HorizontalAlignment="Stretch" />
 
-        <ItemsControl ItemsSource="{Binding Source={StaticResource Roles}}" Grid.Column="2" Grid.Row="0" Grid.RowSpan="3">
+        <ItemsControl ItemsSource="{Binding Source={StaticResource Roles}}" 
+                      Grid.Column="2" Grid.Row="0" 
+                      Grid.RowSpan="3">
             <ItemsControl.ItemsPanel>
                 <ItemsPanelTemplate>
                     <UniformGrid Columns="1"/>
@@ -122,14 +124,15 @@
             </ItemsControl.ItemsPanel>
             <ItemsControl.ItemTemplate>
                 <DataTemplate>
-                    <Grid Margin="5">
+                    <TextBlock>BOO</TextBlock>
+                    <!--<Grid Margin="5">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="*"/>
                         </Grid.RowDefinitions>
-                        <TextBlock Margin="0 0 0 2" FontSize="14" FontFamily="Consolas" Text="{Binding Key}"/>
-                        <ContentControl Grid.Row="1" Content="{Binding Value}" />
-                    </Grid>
+                        <TextBlock Margin="0 0 0 2" FontSize="14" FontFamily="Consolas" Text="Boogallo"/>
+                        --><!--<ContentControl Grid.Row="1" Content="{Binding}" />--><!--
+                    </Grid>-->
                 </DataTemplate>
             </ItemsControl.ItemTemplate>
         </ItemsControl>

--- a/LightBlue.MultiHost/MainWindow.xaml.cs
+++ b/LightBlue.MultiHost/MainWindow.xaml.cs
@@ -13,6 +13,7 @@ using System.Windows.Data;
 using System.Windows.Documents;
 using System.Windows.Media;
 using LightBlue.MultiHost.Configuration;
+using LightBlue.MultiHost.Controls;
 using LightBlue.MultiHost.ViewModel;
 
 namespace LightBlue.MultiHost
@@ -96,6 +97,7 @@ namespace LightBlue.MultiHost
             {
                 var r = new Role(h);
                 Services.Add(r);
+                r.RolePanic += OnRolePanicking;
                 r.PropertyChanged += (s, e) =>
                 {
                     if (e.PropertyName == "Status") CollectionViewSource.View.Refresh();
@@ -110,6 +112,23 @@ namespace LightBlue.MultiHost
 
             var autos = Services.Where(x => x.Status == RoleStatus.Sequenced).ToArray();
             BeginAutoStart(autos);
+
+            Loaded += (s, a) =>
+            {
+                NotificationHub.Initialise(this);
+            };
+        }
+
+        private void OnRolePanicking(object sender, EventArgs e)
+        {
+            var roleSender = sender as Role;
+            if (roleSender == null)
+            {
+                return;
+            }
+
+            SelectedItem = roleSender;
+            listView.ScrollIntoView(roleSender);
         }
 
         public string Version
@@ -224,6 +243,8 @@ namespace LightBlue.MultiHost
                         var index = listView.SelectedIndex;
                         Services.RemoveAt(index);
                         Services.Insert(index, newRole);
+
+                        newRole.RolePanic += OnRolePanicking;
 
                         listView.SelectedIndex = index;
                     }

--- a/LightBlue.MultiHost/Runners/ThreadRunner.cs
+++ b/LightBlue.MultiHost/Runners/ThreadRunner.cs
@@ -40,8 +40,6 @@ namespace LightBlue.MultiHost.Runners
             _configurationFilePath = configurationFilePath;
             _serviceDefinitionFilePath = serviceDefinitionFilePath;
             _roleName = roleName;
-
-            _assemblyFilePath = Path.Combine(ThreadRunnerAssemblyCache.AssemblyCacheFolder, Path.GetFileName(_assemblyFilePath));
         }
 
         public void Start()
@@ -142,7 +140,6 @@ namespace LightBlue.MultiHost.Runners
         private void StartInternal()
         {
             ConfigurationManipulation.RemoveAzureTraceListenerFromConfiguration(_configurationFilePath);
-            //CopyStubAssemblyToRoleDirectory(_appDomainSetup.ApplicationBase, _role);
             _hostStub = new HostStub2();
 
             if (LogicalCallContextTraceListener.IsInitialized)
@@ -155,8 +152,6 @@ namespace LightBlue.MultiHost.Runners
             _traceListener.TraceWriteLine += twlh;
 
             Trace.Listeners.Add(_traceListener);
-
-            //AppDomain.CurrentDomain.AssemblyResolve += (sender, args) => TryResolveAssembly(_assemblyFilePath, args);
 
             try
             {

--- a/LightBlue.MultiHost/Themes/Generic.xaml
+++ b/LightBlue.MultiHost/Themes/Generic.xaml
@@ -7,10 +7,19 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type controls:FifoLog}">
-                    <TextBox x:Name="PART_LogContentDisplayer" TextWrapping="Wrap"
+                    <Grid Margin="5">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        
+                        <Label x:Name="PART_HeaderDisplayer"  Margin="0 0 0 2" FontSize="14" FontFamily="Consolas" ></Label>
+                        <TextBox Grid.Row="1" x:Name="PART_LogContentDisplayer" TextWrapping="Wrap"
                              Background="Black" Foreground="LightGray" 
                              VerticalScrollBarVisibility="Visible" IsReadOnly="True"
                              FontFamily="Consolas" FontSize="14" AcceptsReturn="True" />
+
+                    </Grid>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>

--- a/LightBlue.MultiHost/ViewModel/Role.cs
+++ b/LightBlue.MultiHost/ViewModel/Role.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Threading.Tasks;
 using System.Windows.Media;
 using System.Windows.Threading;
@@ -17,6 +15,8 @@ namespace LightBlue.MultiHost.ViewModel
     public class Role : INotifyPropertyChanged
     {
         private static readonly ConcurrentDictionary<Tuple<string, SolidColorBrush>, ImageSource> ImageCache = new ConcurrentDictionary<Tuple<string, SolidColorBrush>, ImageSource>();
+
+        public event EventHandler<EventArgs> RolePanic;
 
         public RoleStatus Status { get { return State.Status; } }
 
@@ -136,6 +136,15 @@ namespace LightBlue.MultiHost.ViewModel
         public void Crashed()
         {
             State.Crashed();
+            NotificationHub.Notify(Config.Title, "This role has crashed and will be recycled", OnPanic);
+        }
+
+        private void OnPanic()
+        {
+            if (RolePanic != null)
+            {
+                RolePanic(this, EventArgs.Empty);
+            }
         }
 
         public void Stop()

--- a/LightBlue/Infrastructure/HostRunner.cs
+++ b/LightBlue/Infrastructure/HostRunner.cs
@@ -76,7 +76,7 @@ namespace LightBlue.Infrastructure
                 ? workerRoleAssembly
                 : Path.Combine(Environment.CurrentDirectory, workerRoleAssembly);
 
-            var roleAssembly = Assembly.LoadFile(roleAssemblyAbsolutePath);
+            var roleAssembly = Assembly.LoadFrom(roleAssemblyAbsolutePath);
             var workerRoleType = roleAssembly.GetTypes()
                 .Single(t => typeof(RoleEntryPoint).IsAssignableFrom(t));
             return workerRoleType;


### PR DESCRIPTION
Added a simple toast notification (which works 90% of the time due to weirdness in WPF visual state manager / storyboards).

Load entry assembly from its original home rather than threads cache. Allows entry assemblies to make assumptions internally about their surroundings.

Removed a few wpf leaks by removing binding to a dictionary.

@ColinScott  (PR as requested - you might want to run it first before releasing  a new nuget package!!)
