### PR TITLE
windows service host for web and worker roles

### DIFF
--- a/LightBlue.Autofac.nuspec
+++ b/LightBlue.Autofac.nuspec
@@ -5,7 +5,7 @@
     <version>1.1.21-beta</version>
 	<title>LightBlue.Autofac</title>
     <authors>Colin David Scott</authors>
-    <owners>$author$</owners>
+    <owners>Colin David Scott</owners>
     <licenseUrl>https://github.com/LightBlueProject/LightBlue/blob/master/LICENCE</licenseUrl>
     <projectUrl>https://github.com/LightBlueProject/LightBlue</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/LightBlue.Autofac.nuspec
+++ b/LightBlue.Autofac.nuspec
@@ -5,7 +5,7 @@
     <version>1.1.21-beta</version>
 	<title>LightBlue.Autofac</title>
     <authors>Colin David Scott</authors>
-    <owners>Colin David Scott</owners>
+    <owners>$author$</owners>
     <licenseUrl>https://github.com/LightBlueProject/LightBlue/blob/master/LICENCE</licenseUrl>
     <projectUrl>https://github.com/LightBlueProject/LightBlue</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/LightBlue.Autofac/LightBlue.Autofac.nuspec
+++ b/LightBlue.Autofac/LightBlue.Autofac.nuspec
@@ -4,8 +4,8 @@
     <id>$id$</id>
     <version>$version$</version>
 	<title>$id$</title>
-    <authors>Colin David Scott</authors>
-    <owners>Colin David Scott</owners>
+    <authors>$author$</authors>
+    <owners>$author$</owners>
     <licenseUrl>https://github.com/LightBlueProject/LightBlue/blob/master/LICENCE</licenseUrl>
     <projectUrl>https://github.com/LightBlueProject/LightBlue</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/LightBlue.Autofac/LightBlue.Autofac.nuspec
+++ b/LightBlue.Autofac/LightBlue.Autofac.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+	<title>$id$</title>
+    <authors>Colin David Scott</authors>
+    <owners>Colin David Scott</owners>
+    <licenseUrl>https://github.com/LightBlueProject/LightBlue/blob/master/LICENCE</licenseUrl>
+    <projectUrl>https://github.com/LightBlueProject/LightBlue</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Provides Autofac support for the LightBlue Azure development platform</description>
+    <copyright>Copyright 2014-2015 LightBlue contributors</copyright>
+    <tags>azure</tags>
+  </metadata>
+</package>

--- a/LightBlue.Autofac/Properties/AssemblyInfo.cs
+++ b/LightBlue.Autofac/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("LightBlue.Autofac")]
 [assembly: AssemblyDescription("Autofac support for LightBlue")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("Colin David Scott")]
 [assembly: AssemblyProduct("LightBlue.Autofac")]
 [assembly: AssemblyCopyright("Copyright © 2014-2015 LightBlue contributors")]
 [assembly: AssemblyTrademark("")]

--- a/LightBlue.Host.Stub/Properties/AssemblyInfo.cs
+++ b/LightBlue.Host.Stub/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("LightBlue.Host.Stub")]
 [assembly: AssemblyDescription("Stub assembly used by LightBlue to load worker roles. Otherwise harmless.")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("Colin David Scott")]
 [assembly: AssemblyProduct("LightBlue.Host.Stub")]
 [assembly: AssemblyCopyright("Copyright © 2014-2015 LightBlue contributors")]
 [assembly: AssemblyTrademark("")]

--- a/LightBlue.Host/LightBlue.Host.nuspec
+++ b/LightBlue.Host/LightBlue.Host.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+	<title>$id$</title>
+    <authors>Colin David Scott</authors>
+    <owners>Colin David Scott</owners>
+    <licenseUrl>https://github.com/LightBlueProject/LightBlue/blob/master/LICENCE</licenseUrl>
+    <projectUrl>https://github.com/LightBlueProject/LightBlue</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Host executables for the LightBlue lightweight Azure development platform</description>
+    <copyright>Copyright 2014-2015 LightBlue contributors</copyright>
+    <tags>azure</tags>
+  </metadata>
+  <files>
+	<file src="bin\Release\*.dll" target="tools" />
+	<file src="bin\Release\*.exe" target="tools" />
+  </files>
+</package>

--- a/LightBlue.Host/LightBlue.Host.nuspec
+++ b/LightBlue.Host/LightBlue.Host.nuspec
@@ -4,8 +4,8 @@
     <id>$id$</id>
     <version>$version$</version>
 	<title>$id$</title>
-    <authors>Colin David Scott</authors>
-    <owners>Colin David Scott</owners>
+    <authors>$author$</authors>
+    <owners>$author$</owners>
     <licenseUrl>https://github.com/LightBlueProject/LightBlue/blob/master/LICENCE</licenseUrl>
     <projectUrl>https://github.com/LightBlueProject/LightBlue</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/LightBlue.Host/Program.cs
+++ b/LightBlue.Host/Program.cs
@@ -3,9 +3,6 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.InteropServices;
 
-using LightBlue.Host.Stub;
-using LightBlue.Infrastructure;
-
 namespace LightBlue.Host
 {
     public static class Program
@@ -25,36 +22,13 @@ namespace LightBlue.Host
 
             SetWindowText(handle, hostArgs.Title);
 
-            var appDomainSetup = new AppDomainSetup
-            {
-                ApplicationBase = hostArgs.ApplicationBase
-            };
+            var host = WorkerHostFactory.Create(hostArgs);
 
-            ConfigurationManipulation.RemoveAzureTraceListenerFromConfiguration(hostArgs.RoleConfigurationFile);
-            appDomainSetup.ConfigurationFile = hostArgs.RoleConfigurationFile;
-
-            StubManagement.CopyStubAssemblyToRoleDirectory(hostArgs.ApplicationBase);
-
-            var appDomain = AppDomain.CreateDomain(
-                "LightBlue",
-                null,
-                appDomainSetup);
-
-            Trace.Listeners.Add(new ConsoleTraceListener());
-
-            var stub = (HostStub) appDomain.CreateInstanceAndUnwrap(
-                typeof(HostStub).Assembly.FullName,
-                typeof(HostStub).FullName);
-
-            stub.ConfigureTracing(new ConsoleTraceShipper());
-
-            AppDomain.CurrentDomain.UnhandledException += UnhandledExceptionBehaviour.UnhandledExceptionHandler(hostArgs.Title);
-
-            stub.Run(workerRoleAssembly: hostArgs.Assembly,
-                configurationPath: hostArgs.ConfigurationPath,
-                serviceDefinitionPath: hostArgs.ServiceDefinitionPath,
-                roleName: hostArgs.RoleName,
-                useHostedStorage: hostArgs.UseHostedStorage);
+            host.Run(hostArgs.Assembly,
+                hostArgs.ConfigurationPath,
+                hostArgs.ServiceDefinitionPath,
+                hostArgs.RoleName,
+                hostArgs.UseHostedStorage);
 
             if (!hostArgs.AllowSilentFail)
             {

--- a/LightBlue.Host/Properties/AssemblyInfo.cs
+++ b/LightBlue.Host/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("LightBlue.Host")]
 [assembly: AssemblyDescription("Worker role host for the LightBlue Azure development platform.")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("Colin David Scott")]
 [assembly: AssemblyProduct("LightBlue.Host")]
 [assembly: AssemblyCopyright("Copyright © 2014-2015 LightBlue contributors")]
 [assembly: AssemblyTrademark("")]

--- a/LightBlue.Host/WorkerHostFactory.cs
+++ b/LightBlue.Host/WorkerHostFactory.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Diagnostics;
+using LightBlue.Host.Stub;
+using LightBlue.Infrastructure;
+
+namespace LightBlue.Host
+{
+    public static class WorkerHostFactory
+    {
+        public static HostStub Create(HostArgs hostArgs)
+        {
+            var appDomainSetup = new AppDomainSetup
+            {
+                ApplicationBase = hostArgs.ApplicationBase
+            };
+
+            ConfigurationManipulation.RemoveAzureTraceListenerFromConfiguration(hostArgs.RoleConfigurationFile);
+            appDomainSetup.ConfigurationFile = hostArgs.RoleConfigurationFile;
+
+            StubManagement.CopyStubAssemblyToRoleDirectory(hostArgs.ApplicationBase);
+
+            var appDomain = AppDomain.CreateDomain(
+                "LightBlue",
+                null,
+                appDomainSetup);
+
+            Trace.Listeners.Add(new ConsoleTraceListener());
+
+            var stub = (HostStub) appDomain.CreateInstanceAndUnwrap(
+                typeof(HostStub).Assembly.FullName,
+                typeof(HostStub).FullName);
+
+            stub.ConfigureTracing(new ConsoleTraceShipper());
+
+            AppDomain.CurrentDomain.UnhandledException += UnhandledExceptionBehaviour.UnhandledExceptionHandler(hostArgs.Title);
+
+            return stub;
+        }
+    }
+}

--- a/LightBlue.MultiHost/LightBlue.MultiHost.csproj
+++ b/LightBlue.MultiHost/LightBlue.MultiHost.csproj
@@ -181,10 +181,6 @@
     <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\LightBlue.Autofac\LightBlue.Autofac.csproj">
-      <Project>{74b1f607-28dd-4248-af6a-492b03ad321a}</Project>
-      <Name>LightBlue.Autofac</Name>
-    </ProjectReference>
     <ProjectReference Include="..\LightBlue.Host.Stub\LightBlue.Host.Stub.csproj">
       <Project>{0fb3527d-fbcc-468f-91ed-c84e89260791}</Project>
       <Name>LightBlue.Host.Stub</Name>
@@ -211,6 +207,7 @@
   <ItemGroup>
     <Resource Include="Resources\Entypo-license.txt" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/LightBlue.MultiHost/LightBlue.MultiHost.nuspec
+++ b/LightBlue.MultiHost/LightBlue.MultiHost.nuspec
@@ -4,8 +4,8 @@
     <id>$id$</id>
     <version>$version$</version>
 	<title>$id$</title>
-    <authors>Colin David Scott</authors>
-    <owners>Colin David Scott</owners>
+    <authors>$author$</authors>
+    <owners>$author$</owners>
     <licenseUrl>https://github.com/LightBlueProject/LightBlue/blob/master/LICENCE</licenseUrl>
     <projectUrl>https://github.com/LightBlueProject/LightBlue</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/LightBlue.MultiHost/LightBlue.MultiHost.nuspec
+++ b/LightBlue.MultiHost/LightBlue.MultiHost.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+	<title>$id$</title>
+    <authors>Colin David Scott</authors>
+    <owners>Colin David Scott</owners>
+    <licenseUrl>https://github.com/LightBlueProject/LightBlue/blob/master/LICENCE</licenseUrl>
+    <projectUrl>https://github.com/LightBlueProject/LightBlue</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>MultiHost executable for the LightBlue lightweight Azure development platform</description>
+    <copyright>Copyright 2014-2015 LightBlue contributors</copyright>
+    <tags>azure</tags>
+  </metadata>
+  <files>
+	<file src="bin\Release\*.dll" target="tools" />
+	<file src="bin\Release\*.exe" target="tools" />
+  </files>
+</package>

--- a/LightBlue.MultiHost/Properties/AssemblyInfo.cs
+++ b/LightBlue.MultiHost/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Windows;
 [assembly: AssemblyTitle("LightBlue.MultiHost")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("Colin David Scott")]
 [assembly: AssemblyProduct("LightBlue.MultiHost")]
 [assembly: AssemblyCopyright("Copyright © LightBlue contributors 2015")]
 [assembly: AssemblyTrademark("")]

--- a/LightBlue.Testability/LightBlue.Testability.nuspec
+++ b/LightBlue.Testability/LightBlue.Testability.nuspec
@@ -4,8 +4,8 @@
     <id>$id$</id>
     <version>$version$</version>
 	<title>$id$</title>
-    <authors>Colin David Scott</authors>
-    <owners>Colin David Scott</owners>
+    <authors>$author$</authors>
+    <owners>$author$</owners>
     <licenseUrl>https://github.com/LightBlueProject/LightBlue/blob/master/LICENCE</licenseUrl>
     <projectUrl>https://github.com/LightBlueProject/LightBlue</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/LightBlue.Testability/LightBlue.Testability.nuspec
+++ b/LightBlue.Testability/LightBlue.Testability.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+	<title>$id$</title>
+    <authors>Colin David Scott</authors>
+    <owners>Colin David Scott</owners>
+    <licenseUrl>https://github.com/LightBlueProject/LightBlue/blob/master/LICENCE</licenseUrl>
+    <projectUrl>https://github.com/LightBlueProject/LightBlue</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Testing helpers for LightBlue (experimental)</description>
+    <copyright>Copyright 2014-2015 LightBlue contributors</copyright>
+    <tags>azure</tags>
+  </metadata>
+</package>

--- a/LightBlue.Testability/Properties/AssemblyInfo.cs
+++ b/LightBlue.Testability/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("LightBlue.Testability")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("Colin David Scott")]
 [assembly: AssemblyProduct("LightBlue.Testability")]
 [assembly: AssemblyCopyright("Copyright © LightBlue contributors 2015")]
 [assembly: AssemblyTrademark("")]

--- a/LightBlue.Tests/Properties/AssemblyInfo.cs
+++ b/LightBlue.Tests/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("LightBlue.Tests")]
 [assembly: AssemblyDescription("Tests for the LightBlue Azure development platform.")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("Colin David Scott")]
 [assembly: AssemblyProduct("LightBlue.Tests")]
 [assembly: AssemblyCopyright("Copyright © 2014-2015 LightBlue contributors")]
 [assembly: AssemblyTrademark("")]

--- a/LightBlue.WebHost/LightBlue.WebHost.csproj
+++ b/LightBlue.WebHost/LightBlue.WebHost.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="WebHostArgs.cs" />
+    <Compile Include="WebHostFactory.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/LightBlue.WebHost/LightBlue.WebHost.nuspec
+++ b/LightBlue.WebHost/LightBlue.WebHost.nuspec
@@ -4,8 +4,8 @@
 		<id>$id$</id>
 		<version>$version$</version>
 		<title>$id$</title>
-		<authors>Colin David Scott</authors>
-		<owners>Colin David Scott</owners>
+		<authors>$author$</authors>
+		<owners>$author$</owners>
 		<licenseUrl>https://github.com/LightBlueProject/LightBlue/blob/master/LICENCE</licenseUrl>
 		<projectUrl>https://github.com/LightBlueProject/LightBlue</projectUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/LightBlue.WebHost/LightBlue.WebHost.nuspec
+++ b/LightBlue.WebHost/LightBlue.WebHost.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<package >
+	<metadata>
+		<id>$id$</id>
+		<version>$version$</version>
+		<title>$id$</title>
+		<authors>Colin David Scott</authors>
+		<owners>Colin David Scott</owners>
+		<licenseUrl>https://github.com/LightBlueProject/LightBlue/blob/master/LICENCE</licenseUrl>
+		<projectUrl>https://github.com/LightBlueProject/LightBlue</projectUrl>
+		<requireLicenseAcceptance>false</requireLicenseAcceptance>
+		<description>WebHost executables for the LightBlue lightweight Azure development platform</description>
+		<copyright>Copyright 2014-2015 LightBlue contributors</copyright>
+		<tags>azure</tags>
+	</metadata>
+	<files>
+		<file src="bin\Release\*.dll" target="tools" />
+		<file src="bin\Release\*.exe" target="tools" />
+	</files>
+</package>

--- a/LightBlue.WebHost/Program.cs
+++ b/LightBlue.WebHost/Program.cs
@@ -1,12 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Globalization;
-using System.IO;
-using System.Reflection;
 using System.Runtime.InteropServices;
-
-using LightBlue.Host;
-using LightBlue.Host.Stub;
 using LightBlue.Infrastructure;
 
 namespace LightBlue.WebHost
@@ -30,10 +25,13 @@ namespace LightBlue.WebHost
 
                 SetWindowText(handle, webHostArgs.Title);
 
-                ConfigureWebConfig(webHostArgs);
+                var host = WebHostFactory.Create(webHostArgs);
 
-                RunWebSite(webHostArgs);
-                RunWebRole(webHostArgs);
+                host.Run(webHostArgs.Assembly,
+                    webHostArgs.ConfigurationPath,
+                    webHostArgs.ServiceDefinitionPath,
+                    webHostArgs.RoleName,
+                    webHostArgs.UseHostedStorage);
             }
             catch (Exception ex)
             {
@@ -48,148 +46,6 @@ namespace LightBlue.WebHost
                         "The web host {0} has exited unexpectedly",
                         webHostArgs.Title));
             }
-        }
-
-        private static void ConfigureWebConfig(WebHostArgs webHostArgs)
-        {
-            var webConfigFilePath = DetermineWebConfigPath(webHostArgs);
-            if (!File.Exists(webConfigFilePath))
-            {
-                throw new ArgumentException("No web.config could be located for the site");
-            }
-
-            ConfigurationManipulation.RemoveAzureTraceListenerFromConfiguration(webConfigFilePath);
-        }
-
-        private static void RunWebSite(WebHostArgs webHostArgs)
-        {
-            var iisExpressConfigurationFilePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".config");
-            GenerateIisExpressConfigurationFile(webHostArgs, iisExpressConfigurationFilePath);
-
-            using (var process = Process.Start(BuildProcessStartInfo(webHostArgs, iisExpressConfigurationFilePath)))
-            {
-                if (process == null)
-                {
-                    Console.WriteLine("Existing process used.");
-                    return;
-                }
-
-                process.WaitForExit(2000);
-
-                if (process.HasExited)
-                {
-                    Console.WriteLine(process.StandardError.ReadToEnd());
-                }
-            }
-        }
-
-        private static void RunWebRole(WebHostArgs webHostArgs)
-        {
-            var appDomainSetup = new AppDomainSetup
-            {
-                ApplicationBase = webHostArgs.SiteBinDirectory,
-                ConfigurationFile = DetermineWebConfigPath(webHostArgs)
-            };
-
-            StubManagement.CopyStubAssemblyToRoleDirectory(webHostArgs.SiteBinDirectory);
-
-            var appDomain = AppDomain.CreateDomain(
-                "LightBlue",
-                null,
-                appDomainSetup);
-
-            Trace.Listeners.Add(new ConsoleTraceListener());
-
-            var stub = (HostStub) appDomain.CreateInstanceAndUnwrap(
-                typeof(HostStub).Assembly.FullName,
-                typeof(HostStub).FullName);
-
-            stub.ConfigureTracing(new ConsoleTraceShipper());
-
-            AppDomain.CurrentDomain.UnhandledException += UnhandledExceptionBehaviour.UnhandledExceptionHandler(webHostArgs.Title);
-
-            stub.Run(workerRoleAssembly: webHostArgs.Assembly,
-                configurationPath: webHostArgs.ConfigurationPath,
-                serviceDefinitionPath: webHostArgs.ServiceDefinitionPath,
-                roleName: webHostArgs.RoleName,
-                useHostedStorage: webHostArgs.UseHostedStorage);
-        }
-
-        private static string DetermineWebConfigPath(WebHostArgs webHostArgs)
-        {
-            return Path.Combine(webHostArgs.SiteDirectory, "web.config");
-        }
-
-        private static void GenerateIisExpressConfigurationFile(WebHostArgs webHostArgs, string configurationFilePath)
-        {
-            var template = ObtainIisExpressConfigurationTemplate(webHostArgs);
-
-            template = template.Replace("__SITEPATH__", webHostArgs.SiteDirectory);
-            template = template.Replace("__PROTOCOL__", webHostArgs.UseSsl ? "https" : "http");
-            template = template.Replace("__PORT__", webHostArgs.Port.ToString(CultureInfo.InvariantCulture));
-            template = template.Replace("__HOSTNAME__", webHostArgs.Hostname);
-
-            File.WriteAllText(configurationFilePath, template);
-        }
-
-        private static string ObtainIisExpressConfigurationTemplate(WebHostArgs webHostArgs)
-        {
-            if (!string.IsNullOrWhiteSpace(webHostArgs.IisExpressTemplate))
-            {
-                return File.ReadAllText(webHostArgs.IisExpressTemplate);
-            }
-
-            var executingAssembly = Assembly.GetExecutingAssembly();
-            var manifestResourceStream = executingAssembly.GetManifestResourceStream("LightBlue.WebHost.IISExpressConfiguration.template");
-            if (manifestResourceStream == null)
-            {
-                throw new InvalidOperationException("Unable to retrieve IIS Express configuration template.");
-            }
-
-            var template = new StreamReader(manifestResourceStream).ReadToEnd();
-            return template;
-        }
-
-        private static ProcessStartInfo BuildProcessStartInfo(WebHostArgs webHostArgs, string configurationFilePath)
-        {
-            string path = webHostArgs.Use64Bit
-                ? Path.Combine(Environment.GetEnvironmentVariable("ProgramW6432"), @"IIS Express\iisexpress.exe")
-                : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),@"IIS Express\iisexpress.exe");
-
-            var processStartInfo = new ProcessStartInfo
-            {
-                FileName = path,
-                Arguments = string.Format(
-                    CultureInfo.InvariantCulture,
-                    "/config:\"{0}\" /site:LightBlue",
-                    configurationFilePath),
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-                CreateNoWindow = true
-            };
-
-            processStartInfo.EnvironmentVariables.Add("LightBlueHost", "true");
-            processStartInfo.EnvironmentVariables.Add("LightBlueConfigurationPath", webHostArgs.ConfigurationPath);
-            processStartInfo.EnvironmentVariables.Add("LightBlueServiceDefinitionPath", webHostArgs.ServiceDefinitionPath);
-            processStartInfo.EnvironmentVariables.Add("LightBlueRoleName", webHostArgs.RoleName);
-            processStartInfo.EnvironmentVariables.Add("LightBlueUseHostedStorage", webHostArgs.UseHostedStorage.ToString());
-
-            var processId = webHostArgs.RoleName
-                + "-web-"
-                + Process.GetCurrentProcess().Id.ToString(CultureInfo.InvariantCulture);
-
-            var temporaryDirectory = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                "LightBlue",
-                "temp",
-                processId);
-
-            Directory.CreateDirectory(temporaryDirectory);
-            processStartInfo.EnvironmentVariables["TMP"] = temporaryDirectory;
-            processStartInfo.EnvironmentVariables["TEMP"] = temporaryDirectory;
-
-            return processStartInfo;
         }
     }
 }

--- a/LightBlue.WebHost/Properties/AssemblyInfo.cs
+++ b/LightBlue.WebHost/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("LightBlue.WebHost")]
 [assembly: AssemblyDescription("Web role host for the LightBlue Azure development platform.")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("Colin David Scott")]
 [assembly: AssemblyProduct("LightBlue.WebHost")]
 [assembly: AssemblyCopyright("Copyright © 2014-2015 LightBlue contributors")]
 [assembly: AssemblyTrademark("")]

--- a/LightBlue.WebHost/WebHostFactory.cs
+++ b/LightBlue.WebHost/WebHostFactory.cs
@@ -1,0 +1,159 @@
+﻿using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Reflection;
+using LightBlue.Host;
+using LightBlue.Host.Stub;
+using LightBlue.Infrastructure;
+
+namespace LightBlue.WebHost
+{
+    public static class WebHostFactory
+    {
+        public static HostStub Create(WebHostArgs webHostArgs)
+        {
+            ConfigureWebConfig(webHostArgs);
+            RunWebSite(webHostArgs);
+            return RunWebRole(webHostArgs);
+        }
+
+        private static void ConfigureWebConfig(WebHostArgs webHostArgs)
+        {
+            var webConfigFilePath = DetermineWebConfigPath(webHostArgs);
+            if (!File.Exists(webConfigFilePath))
+            {
+                throw new ArgumentException("No web.config could be located for the site");
+            }
+
+            ConfigurationManipulation.RemoveAzureTraceListenerFromConfiguration(webConfigFilePath);
+        }
+
+        private static void RunWebSite(WebHostArgs webHostArgs)
+        {
+            var iisExpressConfigurationFilePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".config");
+            GenerateIisExpressConfigurationFile(webHostArgs, iisExpressConfigurationFilePath);
+
+            using (var process = Process.Start(BuildProcessStartInfo(webHostArgs, iisExpressConfigurationFilePath)))
+            {
+                if (process == null)
+                {
+                    Console.WriteLine("Existing process used.");
+                    return;
+                }
+
+                process.WaitForExit(2000);
+
+                if (process.HasExited)
+                {
+                    Console.WriteLine(process.StandardError.ReadToEnd());
+                }
+            }
+        }
+
+        private static HostStub RunWebRole(WebHostArgs webHostArgs)
+        {
+            var appDomainSetup = new AppDomainSetup
+            {
+                ApplicationBase = webHostArgs.SiteBinDirectory,
+                ConfigurationFile = DetermineWebConfigPath(webHostArgs)
+            };
+
+            StubManagement.CopyStubAssemblyToRoleDirectory(webHostArgs.SiteBinDirectory);
+
+            var appDomain = AppDomain.CreateDomain(
+                "LightBlue",
+                null,
+                appDomainSetup);
+
+            Trace.Listeners.Add(new ConsoleTraceListener());
+
+            var stub = (HostStub)appDomain.CreateInstanceAndUnwrap(
+                typeof(HostStub).Assembly.FullName,
+                typeof(HostStub).FullName);
+
+            stub.ConfigureTracing(new ConsoleTraceShipper());
+
+            AppDomain.CurrentDomain.UnhandledException += UnhandledExceptionBehaviour.UnhandledExceptionHandler(webHostArgs.Title);
+
+            return stub;
+        }
+
+        private static string DetermineWebConfigPath(WebHostArgs webHostArgs)
+        {
+            return Path.Combine(webHostArgs.SiteDirectory, "web.config");
+        }
+
+        private static void GenerateIisExpressConfigurationFile(WebHostArgs webHostArgs, string configurationFilePath)
+        {
+            var template = ObtainIisExpressConfigurationTemplate(webHostArgs);
+
+            template = template.Replace("__SITEPATH__", webHostArgs.SiteDirectory);
+            template = template.Replace("__PROTOCOL__", webHostArgs.UseSsl ? "https" : "http");
+            template = template.Replace("__PORT__", webHostArgs.Port.ToString(CultureInfo.InvariantCulture));
+            template = template.Replace("__HOSTNAME__", webHostArgs.Hostname);
+
+            File.WriteAllText(configurationFilePath, template);
+        }
+
+        private static string ObtainIisExpressConfigurationTemplate(WebHostArgs webHostArgs)
+        {
+            if (!string.IsNullOrWhiteSpace(webHostArgs.IisExpressTemplate))
+            {
+                return File.ReadAllText(webHostArgs.IisExpressTemplate);
+            }
+
+            var executingAssembly = Assembly.GetExecutingAssembly();
+            var manifestResourceStream = executingAssembly.GetManifestResourceStream("LightBlue.WebHost.IISExpressConfiguration.template");
+            if (manifestResourceStream == null)
+            {
+                throw new InvalidOperationException("Unable to retrieve IIS Express configuration template.");
+            }
+
+            var template = new StreamReader(manifestResourceStream).ReadToEnd();
+            return template;
+        }
+
+        private static ProcessStartInfo BuildProcessStartInfo(WebHostArgs webHostArgs, string configurationFilePath)
+        {
+            string path = webHostArgs.Use64Bit
+                ? Path.Combine(Environment.GetEnvironmentVariable("ProgramW6432"), @"IIS Express\iisexpress.exe")
+                : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), @"IIS Express\iisexpress.exe");
+
+            var processStartInfo = new ProcessStartInfo
+            {
+                FileName = path,
+                Arguments = string.Format(
+                    CultureInfo.InvariantCulture,
+                    "/config:\"{0}\" /site:LightBlue",
+                    configurationFilePath),
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            processStartInfo.EnvironmentVariables.Add("LightBlueHost", "true");
+            processStartInfo.EnvironmentVariables.Add("LightBlueConfigurationPath", webHostArgs.ConfigurationPath);
+            processStartInfo.EnvironmentVariables.Add("LightBlueServiceDefinitionPath", webHostArgs.ServiceDefinitionPath);
+            processStartInfo.EnvironmentVariables.Add("LightBlueRoleName", webHostArgs.RoleName);
+            processStartInfo.EnvironmentVariables.Add("LightBlueUseHostedStorage", webHostArgs.UseHostedStorage.ToString());
+
+            var processId = webHostArgs.RoleName
+                + "-web-"
+                + Process.GetCurrentProcess().Id.ToString(CultureInfo.InvariantCulture);
+
+            var temporaryDirectory = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "LightBlue",
+                "temp",
+                processId);
+
+            Directory.CreateDirectory(temporaryDirectory);
+            processStartInfo.EnvironmentVariables["TMP"] = temporaryDirectory;
+            processStartInfo.EnvironmentVariables["TEMP"] = temporaryDirectory;
+
+            return processStartInfo;
+        }
+    }
+}

--- a/LightBlue.WebService/App.config
+++ b/LightBlue.WebService/App.config
@@ -1,20 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="Assembly" value="C:\Source\LightBlue\TestWebRole\bin\TestWebRole.dll"/>
-    <add key="Port" value="443"/>
-    <add key="RoleName" value="TestWebRole"/>
-    <add key="ServiceTitle" value="TestWebRoleService"/>
-    <add key="Configuration" value="C:\Source\LightBlue\TestCloudService"/>
-    <add key="UseSSL" value="true"/>
-    <add key="Host" value="localhost"/>
+    <add key="Assembly" value="C:\Source\LightBlue\TestWebRole\bin\TestWebRole.dll" />
+    <add key="Port" value="443" />
+    <add key="RoleName" value="TestWebRole" />
+    <add key="ServiceTitle" value="TestWebRoleService" />
+    <add key="Configuration" value="C:\Source\LightBlue\TestCloudService" />
+    <add key="UseSSL" value="true" />
+    <add key="Host" value="localhost" />
   </appSettings>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+    </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
-      </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-5.6.3.0" newVersion="5.6.3.0" />
@@ -26,6 +25,10 @@
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-5.6.3.0" newVersion="5.6.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/LightBlue.WebService/LightBlue.WebService.csproj
+++ b/LightBlue.WebService/LightBlue.WebService.csproj
@@ -1,18 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{D6110338-D945-4E32-8A72-840C44EDA2B9}</ProjectGuid>
+    <ProjectGuid>{0BCCB2BA-430B-41AA-BA5E-A9C9EF88D301}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>LightBlue.Host</RootNamespace>
-    <AssemblyName>LightBlue.Host</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <RootNamespace>LightBlue.WebService</RootNamespace>
+    <AssemblyName>LightBlue.WebService</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
-    <RestorePackages>true</RestorePackages>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -23,7 +22,6 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -33,14 +31,11 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.WindowsAzure.ServiceRuntime, Version=2.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="NDesk.Options">
-      <HintPath>..\packages\NDesk.Options.0.2.1\lib\NDesk.Options.dll</HintPath>
+    <Reference Include="Formo, Version=1.4.4.40853, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Formo.1.4.4.40853\lib\net40\Formo.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -48,45 +43,34 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="Topshelf, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b800c4cfcdeea87b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Topshelf.4.0.2\lib\net452\Topshelf.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\LightBlue\Infrastructure\ConfigurationLocator.cs">
-      <Link>ConfigurationLocator.cs</Link>
-    </Compile>
-    <Compile Include="..\LightBlue\Infrastructure\ConfigurationManipulation.cs">
-      <Link>ConfigurationManipulation.cs</Link>
-    </Compile>
-    <Compile Include="..\LightBlue\Infrastructure\ExceptionExtensions.cs">
-      <Link>ExceptionExtensions.cs</Link>
-    </Compile>
-    <Compile Include="HostArgs.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="StubManagement.cs" />
-    <Compile Include="UnhandledExceptionBehaviour.cs" />
-    <Compile Include="WorkerHostFactory.cs" />
+    <Compile Include="WebHostService.cs" />
+    <Compile Include="WebHostSettings.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="App.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\LightBlue.Host.Stub\LightBlue.Host.Stub.csproj">
-      <Project>{0fb3527d-fbcc-468f-91ed-c84e89260791}</Project>
+      <Project>{0FB3527D-FBCC-468F-91ED-C84E89260791}</Project>
       <Name>LightBlue.Host.Stub</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\LightBlue.WebHost\LightBlue.WebHost.csproj">
+      <Project>{871c2b31-fb84-499f-a1b7-901ddabda8d4}</Project>
+      <Name>LightBlue.WebHost</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/LightBlue.WebService/LightBlue.WebService.nuspec
+++ b/LightBlue.WebService/LightBlue.WebService.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+	<title>$id$</title>
+    <authors>Colin David Scott</authors>
+    <owners>Colin David Scott</owners>
+    <licenseUrl>https://github.com/LightBlueProject/LightBlue/blob/master/LICENCE</licenseUrl>
+    <projectUrl>https://github.com/LightBlueProject/LightBlue</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Windows service web role support for the LightBlue Azure development platform</description>
+    <copyright>Copyright 2014-2015 LightBlue contributors</copyright>
+    <tags>azure</tags>
+  </metadata>
+  <files>
+	<file src="bin\Release\*.dll" target="tools" />
+	<file src="bin\Release\*.exe" target="tools" />
+  </files>
+</package>

--- a/LightBlue.WebService/LightBlue.WebService.nuspec
+++ b/LightBlue.WebService/LightBlue.WebService.nuspec
@@ -4,8 +4,8 @@
     <id>$id$</id>
     <version>$version$</version>
 	<title>$id$</title>
-    <authors>Colin David Scott</authors>
-    <owners>Colin David Scott</owners>
+    <authors>$author$</authors>
+    <owners>$author$</owners>
     <licenseUrl>https://github.com/LightBlueProject/LightBlue/blob/master/LICENCE</licenseUrl>
     <projectUrl>https://github.com/LightBlueProject/LightBlue</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/LightBlue.WebService/Program.cs
+++ b/LightBlue.WebService/Program.cs
@@ -1,0 +1,44 @@
+﻿using Formo;
+using LightBlue.WebHost;
+using Topshelf;
+
+namespace LightBlue.WebService
+{
+    class Program
+    {
+        static int Main(string[] args)
+        {
+           return (int)HostFactory.Run(x =>
+           {
+               dynamic configuration = new Configuration();
+               WebHostSettings settings = configuration.Bind<WebHostSettings>();
+
+               x.Service<WebHostService>(service =>
+               {
+                   service.ConstructUsing(s =>
+                   {
+                       var hostArgs = WebHostArgs.ParseArgs(new[]
+                       {
+                           "-a:" + settings.Assembly,
+                           "-p:" + settings.Port,
+                           "-n:" + settings.RoleName,
+                           "-t:" + settings.ServiceTitle,
+                           "-c:" + settings.Configuration,
+                           "-s:" + settings.UseSSL,
+                           "-h:" + settings.Host
+                       });
+                       return new WebHostService(hostArgs);
+                   });
+                   service.WhenStarted((s, h) => s.Start(h));
+                   service.WhenStopped((s, h) => s.Stop(h));
+               });
+
+               x.RunAsLocalSystem();
+               x.SetDescription(string.Format("LightBlue {0} WebRole Windows Service", settings.ServiceTitle));
+               x.SetDisplayName(settings.ServiceTitle + " Service");
+               x.SetServiceName(settings.ServiceTitle);
+               x.StartManually();
+           });
+        }
+    }
+}

--- a/LightBlue.WebService/Properties/AssemblyInfo.cs
+++ b/LightBlue.WebService/Properties/AssemblyInfo.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("LightBlue.WebService")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("Colin David Scott")]
 [assembly: AssemblyProduct("LightBlue.WebService")]
 [assembly: AssemblyCopyright("Copyright ©  2016")]
 [assembly: AssemblyTrademark("")]

--- a/LightBlue.WebService/Properties/AssemblyInfo.cs
+++ b/LightBlue.WebService/Properties/AssemblyInfo.cs
@@ -1,0 +1,37 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("LightBlue.WebService")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("LightBlue.WebService")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("0bccb2ba-430b-41aa-ba5e-a9c9ef88d301")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/LightBlue.WebService/WebHostService.cs
+++ b/LightBlue.WebService/WebHostService.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Threading;
+using LightBlue.Host.Stub;
+using LightBlue.WebHost;
+using Topshelf;
+
+namespace LightBlue.WebService
+{
+    public class WebHostService : ServiceControl
+    {
+        private readonly WebHostArgs _hostArgs;
+        private HostStub _stub;
+
+        public WebHostService(WebHostArgs hostArgs)
+        {
+            _hostArgs = hostArgs;
+        }
+
+        public bool Start(HostControl hostControl)
+        {
+            ThreadPool.QueueUserWorkItem(x =>
+            {
+                try
+                {
+                    _stub = WebHostFactory.Create(_hostArgs);
+
+                    _stub.Run(_hostArgs.Assembly,
+                        _hostArgs.ConfigurationPath,
+                        _hostArgs.ServiceDefinitionPath,
+                        _hostArgs.RoleName,
+                        _hostArgs.UseHostedStorage);
+                }
+                catch (Exception)
+                {
+                    hostControl.Stop();
+
+                    throw;
+                }
+            });
+
+            return true;
+        }
+
+        public bool Stop(HostControl hostControl)
+        {
+            _stub.RequestShutdown();
+
+            return true;
+        }
+    }
+}

--- a/LightBlue.WebService/WebHostSettings.cs
+++ b/LightBlue.WebService/WebHostSettings.cs
@@ -1,0 +1,13 @@
+﻿namespace LightBlue.WebService
+{
+    public class WebHostSettings
+    {
+        public string Assembly { get; set; }
+        public string Port { get; set; }
+        public string RoleName { get; set; }
+        public string ServiceTitle { get; set; }
+        public string Configuration { get; set; }
+        public bool UseSSL { get; set; }
+        public string Host { get; set; }
+    }
+}

--- a/LightBlue.WebService/packages.config
+++ b/LightBlue.WebService/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Formo" version="1.4.4.40853" targetFramework="net461" />
+  <package id="Topshelf" version="4.0.2" targetFramework="net461" />
+</packages>

--- a/LightBlue.Windsor/LightBlue.Windsor.nuspec
+++ b/LightBlue.Windsor/LightBlue.Windsor.nuspec
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+	<title>$id$</title>
+    <authors>Colin David Scott</authors>
+    <owners>Colin David Scott</owners>
+    <licenseUrl>https://github.com/LightBlueProject/LightBlue/blob/master/LICENCE</licenseUrl>
+    <projectUrl>https://github.com/LightBlueProject/LightBlue</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Provides Windsor support for the LightBlue Azure development platform</description>
+    <copyright>Copyright 2014-2015 LightBlue contributors</copyright>
+    <tags>azure</tags>
+    <dependencies>
+    </dependencies>
+  </metadata>
+</package>

--- a/LightBlue.Windsor/LightBlue.Windsor.nuspec
+++ b/LightBlue.Windsor/LightBlue.Windsor.nuspec
@@ -4,8 +4,8 @@
     <id>$id$</id>
     <version>$version$</version>
 	<title>$id$</title>
-    <authors>Colin David Scott</authors>
-    <owners>Colin David Scott</owners>
+    <authors>$author$</authors>
+    <owners>$author$</owners>
     <licenseUrl>https://github.com/LightBlueProject/LightBlue/blob/master/LICENCE</licenseUrl>
     <projectUrl>https://github.com/LightBlueProject/LightBlue</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/LightBlue.Windsor/Properties/AssemblyInfo.cs
+++ b/LightBlue.Windsor/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("LightBlue.Windsor")]
 [assembly: AssemblyDescription("Castle Windsor support for LightBlue")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("Colin David Scott")]
 [assembly: AssemblyProduct("LightBlue.Windsor")]
 [assembly: AssemblyCopyright("Copyright © 2014-2015 LightBlue contributors")]
 [assembly: AssemblyTrademark("")]

--- a/LightBlue.WorkerRoleDependency/Properties/AssemblyInfo.cs
+++ b/LightBlue.WorkerRoleDependency/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("LightBlue.WorkerRoleDependency")]
 [assembly: AssemblyDescription("Dependent library used by the LightBlue test worker role to verify assembly loading.")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("Colin David Scott")]
 [assembly: AssemblyProduct("LightBlue.WorkerRoleDependency")]
 [assembly: AssemblyCopyright("Copyright © 2014-2015 LightBlue contributors")]
 [assembly: AssemblyTrademark("")]

--- a/LightBlue.WorkerService/App.config
+++ b/LightBlue.WorkerService/App.config
@@ -1,20 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="Assembly" value="C:\Source\LightBlue\TestWebRole\bin\TestWebRole.dll"/>
-    <add key="Port" value="443"/>
-    <add key="RoleName" value="TestWebRole"/>
-    <add key="ServiceTitle" value="TestWebRoleService"/>
-    <add key="Configuration" value="C:\Source\LightBlue\TestCloudService"/>
-    <add key="UseSSL" value="true"/>
-    <add key="Host" value="localhost"/>
+    <add key="Assembly" value="C:\Source\LightBlue\TestWorkerRole\bin\Debug\TestWorkerRole.dll" />
+    <add key="RoleName" value="TestWorkerRole" />
+    <add key="ServiceTitle" value="TestWorkerRoleService" />
+    <add key="Configuration" value="C:\Source\LightBlue\TestCloudService\ServiceConfiguration.Local.cscfg" />
   </appSettings>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+    </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
-      </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-5.6.3.0" newVersion="5.6.3.0" />
@@ -26,6 +22,10 @@
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-5.6.3.0" newVersion="5.6.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/LightBlue.WorkerService/LightBlue.WorkerService.csproj
+++ b/LightBlue.WorkerService/LightBlue.WorkerService.csproj
@@ -1,18 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{D6110338-D945-4E32-8A72-840C44EDA2B9}</ProjectGuid>
+    <ProjectGuid>{EEF47CD4-2AAF-4EC0-8982-7C748AA0E3BA}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>LightBlue.Host</RootNamespace>
-    <AssemblyName>LightBlue.Host</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <RootNamespace>LightBlue.WorkerService</RootNamespace>
+    <AssemblyName>LightBlue.WorkerService</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
-    <RestorePackages>true</RestorePackages>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -23,7 +22,6 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -33,14 +31,11 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.WindowsAzure.ServiceRuntime, Version=2.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="NDesk.Options">
-      <HintPath>..\packages\NDesk.Options.0.2.1\lib\NDesk.Options.dll</HintPath>
+    <Reference Include="Formo, Version=1.4.4.40853, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Formo.1.4.4.40853\lib\net40\Formo.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -48,45 +43,34 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="Topshelf, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b800c4cfcdeea87b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Topshelf.4.0.2\lib\net452\Topshelf.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\LightBlue\Infrastructure\ConfigurationLocator.cs">
-      <Link>ConfigurationLocator.cs</Link>
-    </Compile>
-    <Compile Include="..\LightBlue\Infrastructure\ConfigurationManipulation.cs">
-      <Link>ConfigurationManipulation.cs</Link>
-    </Compile>
-    <Compile Include="..\LightBlue\Infrastructure\ExceptionExtensions.cs">
-      <Link>ExceptionExtensions.cs</Link>
-    </Compile>
-    <Compile Include="HostArgs.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="StubManagement.cs" />
-    <Compile Include="UnhandledExceptionBehaviour.cs" />
-    <Compile Include="WorkerHostFactory.cs" />
+    <Compile Include="WorkerHostService.cs" />
+    <Compile Include="WorkerHostSettings.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="App.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\LightBlue.Host.Stub\LightBlue.Host.Stub.csproj">
-      <Project>{0fb3527d-fbcc-468f-91ed-c84e89260791}</Project>
+      <Project>{0FB3527D-FBCC-468F-91ED-C84E89260791}</Project>
       <Name>LightBlue.Host.Stub</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\LightBlue.Host\LightBlue.Host.csproj">
+      <Project>{d6110338-d945-4e32-8a72-840c44eda2b9}</Project>
+      <Name>LightBlue.Host</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/LightBlue.WorkerService/LightBlue.WorkerService.nuspec
+++ b/LightBlue.WorkerService/LightBlue.WorkerService.nuspec
@@ -4,8 +4,8 @@
 		<id>$id$</id>
 		<version>$version$</version>
 		<title>$id$</title>
-		<authors>Colin David Scott</authors>
-		<owners>Colin David Scott</owners>
+		<authors>$author$</authors>
+		<owners>$author$</owners>
 		<licenseUrl>https://github.com/LightBlueProject/LightBlue/blob/master/LICENCE</licenseUrl>
 		<projectUrl>https://github.com/LightBlueProject/LightBlue</projectUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/LightBlue.WorkerService/LightBlue.WorkerService.nuspec
+++ b/LightBlue.WorkerService/LightBlue.WorkerService.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<package >
+	<metadata>
+		<id>$id$</id>
+		<version>$version$</version>
+		<title>$id$</title>
+		<authors>Colin David Scott</authors>
+		<owners>Colin David Scott</owners>
+		<licenseUrl>https://github.com/LightBlueProject/LightBlue/blob/master/LICENCE</licenseUrl>
+		<projectUrl>https://github.com/LightBlueProject/LightBlue</projectUrl>
+		<requireLicenseAcceptance>false</requireLicenseAcceptance>
+		<description>Windows service worker role support for the LightBlue Azure development platform</description>
+		<copyright>Copyright 2014-2015 LightBlue contributors</copyright>
+		<tags>azure</tags>
+	</metadata>
+	<files>
+		<file src="bin\Release\*.dll" target="tools" />
+		<file src="bin\Release\*.exe" target="tools" />
+	</files>
+</package>

--- a/LightBlue.WorkerService/Program.cs
+++ b/LightBlue.WorkerService/Program.cs
@@ -1,0 +1,42 @@
+﻿using Formo;
+using LightBlue.Host;
+using Topshelf;
+
+namespace LightBlue.WorkerService
+{
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            return (int)HostFactory.Run(x =>
+            {
+                dynamic configuration = new Configuration();
+                WorkerHostSettings settings = configuration.Bind<WorkerHostSettings>();
+
+                x.Service<WorkerHostService>(service =>
+                {
+                    service.ConstructUsing(s =>
+                    {
+                        var hostArgs = HostArgs.ParseArgs(new[]
+                        {
+                            "-a:" + settings.Assembly,
+                            "-n:" + settings.RoleName,
+                            "-t:" + settings.ServiceTitle,
+                            "-c:" + settings.Configuration
+                        });
+                        return new WorkerHostService(hostArgs);
+                    });
+
+                    service.WhenStarted((s, h) => s.Start(h));
+                    service.WhenStopped((s, h) => s.Stop(h));
+                });
+
+                x.RunAsLocalSystem();
+                x.SetDescription(string.Format("LightBlue {0} WorkerRole Windows Service", settings.ServiceTitle));
+                x.SetDisplayName(settings.ServiceTitle + " Service");
+                x.SetServiceName(settings.ServiceTitle);
+                x.StartManually();
+            });
+        }
+    }
+}

--- a/LightBlue.WorkerService/Properties/AssemblyInfo.cs
+++ b/LightBlue.WorkerService/Properties/AssemblyInfo.cs
@@ -1,0 +1,37 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("LightBlue.WorkerService")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("LightBlue.WorkerService")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("eef47cd4-2aaf-4ec0-8982-7c748aa0e3ba")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/LightBlue.WorkerService/Properties/AssemblyInfo.cs
+++ b/LightBlue.WorkerService/Properties/AssemblyInfo.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("LightBlue.WorkerService")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("Colin David Scott")]
 [assembly: AssemblyProduct("LightBlue.WorkerService")]
 [assembly: AssemblyCopyright("Copyright ©  2016")]
 [assembly: AssemblyTrademark("")]

--- a/LightBlue.WorkerService/WorkerHostService.cs
+++ b/LightBlue.WorkerService/WorkerHostService.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Threading;
+using LightBlue.Host;
+using LightBlue.Host.Stub;
+using Topshelf;
+
+namespace LightBlue.WorkerService
+{
+    public class WorkerHostService : ServiceControl
+    {
+        private readonly HostArgs _hostArgs;
+        private HostStub _stub;
+
+        public WorkerHostService(HostArgs hostArgs)
+        {
+            _hostArgs = hostArgs;
+        }
+         
+        public bool Start(HostControl hostControl)
+        {
+            ThreadPool.QueueUserWorkItem(x =>
+            {
+                try
+                {
+                    _stub = WorkerHostFactory.Create(_hostArgs);
+
+                    _stub.Run(_hostArgs.Assembly,
+                        _hostArgs.ConfigurationPath,
+                        _hostArgs.ServiceDefinitionPath,
+                        _hostArgs.RoleName,
+                        _hostArgs.UseHostedStorage);
+                }
+                catch (Exception)
+                {
+                    hostControl.Stop();
+
+                    throw;
+                }
+            });
+
+            return true;
+        }
+
+        public bool Stop(HostControl hostControl)
+        {
+            _stub.RequestShutdown();
+
+            return true;
+        }
+    }
+}

--- a/LightBlue.WorkerService/WorkerHostSettings.cs
+++ b/LightBlue.WorkerService/WorkerHostSettings.cs
@@ -1,0 +1,10 @@
+﻿namespace LightBlue.WorkerService
+{
+    public class WorkerHostSettings
+    {
+        public string Assembly { get; set; }
+        public string RoleName { get; set; }
+        public string ServiceTitle { get; set; }
+        public string Configuration { get; set; }
+    }
+}

--- a/LightBlue.WorkerService/packages.config
+++ b/LightBlue.WorkerService/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Formo" version="1.4.4.40853" targetFramework="net461" />
+  <package id="Topshelf" version="4.0.2" targetFramework="net461" />
+</packages>

--- a/LightBlue.sln
+++ b/LightBlue.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LightBlue", "LightBlue\LightBlue.csproj", "{28F5B274-4B25-4295-98AE-3E5A60C34D8D}"
 EndProject
@@ -37,6 +37,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LightBlue.MultiHost", "LightBlue.MultiHost\LightBlue.MultiHost.csproj", "{EF7E48CD-46B5-4552-9149-FCCF51CB7AA9}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LightBlue.Testability", "LightBlue.Testability\LightBlue.Testability.csproj", "{697A6A25-955B-4C17-82F8-F14FD48A5A42}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LightBlue.WebService", "LightBlue.WebService\LightBlue.WebService.csproj", "{0BCCB2BA-430B-41AA-BA5E-A9C9EF88D301}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LightBlue.WorkerService", "LightBlue.WorkerService\LightBlue.WorkerService.csproj", "{EEF47CD4-2AAF-4EC0-8982-7C748AA0E3BA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -100,6 +104,14 @@ Global
 		{697A6A25-955B-4C17-82F8-F14FD48A5A42}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{697A6A25-955B-4C17-82F8-F14FD48A5A42}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{697A6A25-955B-4C17-82F8-F14FD48A5A42}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0BCCB2BA-430B-41AA-BA5E-A9C9EF88D301}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0BCCB2BA-430B-41AA-BA5E-A9C9EF88D301}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0BCCB2BA-430B-41AA-BA5E-A9C9EF88D301}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0BCCB2BA-430B-41AA-BA5E-A9C9EF88D301}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EEF47CD4-2AAF-4EC0-8982-7C748AA0E3BA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EEF47CD4-2AAF-4EC0-8982-7C748AA0E3BA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EEF47CD4-2AAF-4EC0-8982-7C748AA0E3BA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EEF47CD4-2AAF-4EC0-8982-7C748AA0E3BA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/LightBlue/LightBlue.nuspec
+++ b/LightBlue/LightBlue.nuspec
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+	<title>$id$</title>
+    <authors>Colin David Scott</authors>
+    <owners>Colin David Scott</owners>
+    <licenseUrl>https://github.com/LightBlueProject/LightBlue/blob/master/LICENCE</licenseUrl>
+    <projectUrl>https://github.com/LightBlueProject/LightBlue</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>LightBlue is a lightweight Azure development platform designed to replace a subset of the Azure emulator functionality</description>
+    <copyright>Copyright 2014-2015 LightBlue contributors</copyright>
+    <tags>azure</tags>
+    <dependencies>
+      <dependency id="Microsoft.Data.Edm" version="5.6.3" />
+      <dependency id="Microsoft.Data.OData" version="5.6.3" />
+      <dependency id="Microsoft.Data.Services.Client" version="5.6.3" />
+      <dependency id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3" />
+      <dependency id="Newtonsoft.Json" version="6.0.8" />
+      <dependency id="System.Spatial" version="5.6.3" />
+      <dependency id="WindowsAzure.Storage" version="4.3.0" />
+    </dependencies>
+  </metadata>
+</package>

--- a/LightBlue/Properties/AssemblyInfo.cs
+++ b/LightBlue/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("LightBlue")]
 [assembly: AssemblyDescription("LightBlue is a lightweight development platform for Azure.")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("Colin David Scott")]
 [assembly: AssemblyProduct("LightBlue")]
 [assembly: AssemblyCopyright("Copyright © 2014-2015 LightBlue contributors")]
 [assembly: AssemblyTrademark("")]

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,6 +1,12 @@
 LightBlue
 ====================
 
+Version 1.1.22
+--------------------
+Features:
+* Worker role windows service hosting
+* Web role windows service hosting
+
 Version 1.1.21
 --------------------
 ###Implementation

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,7 +1,7 @@
 LightBlue
 ====================
 
-Version 1.1.22
+Version 2.0.0
 --------------------
 Features:
 * Worker role windows service hosting

--- a/Scripts/PackageNuget.ps1
+++ b/Scripts/PackageNuget.ps1
@@ -24,10 +24,20 @@ $workerHostStubDllPath = join-path $parentDirectory "LightBlue.Host\bin\Release\
 $workerHostStubPdbPath = join-path $parentDirectory "LightBlue.Host\bin\Release\LightBlue.Host.Stub.pdb"
 $webHostExePath = join-path $parentDirectory "LightBlue.WebHost\bin\Release\LightBlue.WebHost.exe"
 $webHostPdbPath = join-path $parentDirectory "LightBlue.WebHost\bin\Release\LightBlue.WebHost.pdb"
+
+
+
 $multiHostExePath = join-path $parentDirectory "LightBlue.MultiHost\bin\Release\*.exe"
 $multiHostDllPath = join-path $parentDirectory "LightBlue.MultiHost\bin\Release\*.dll"
 $multiHostPdbPath = join-path $parentDirectory "LightBlue.MultiHost\bin\Release\*.pdb"
 $multiHostConfigPath = join-path $parentDirectory "LightBlue.MultiHost\bin\Release\*.config"
+
+$webServiceHostExePath = join-path $parentDirectory "LightBlue.WebService\bin\Release\*.exe"
+$webServiceHostPdbPath = join-path $parentDirectory "LightBlue.WebService\bin\Release\*.pdb"
+$webServiceHostDllPath = join-path $parentDirectory "LightBlue.WebService\bin\Release\*.dll"
+$workerServiceHostExePath = join-path $parentDirectory "LightBlue.WorkerService\bin\Release\*.exe"
+$workerServiceHostPdbPath = join-path $parentDirectory "LightBlue.WorkerService\bin\Release\*.pdb"
+$workerServiceHostDllPath = join-path $parentDirectory "LightBlue.WorkerService\bin\Release\*.dll"
 
 $ndeskDllPath = join-path $parentDirectory "LightBlue.Host\bin\Release\NDesk.Options.dll"
 
@@ -63,8 +73,8 @@ New-Item -ItemType directory -Path $outputDirectory | Out-Null
 New-Item -ItemType directory -Path $coreNet45LibPath | Out-Null
 New-Item -ItemType directory -Path $linqpadSamplesPath | Out-Null
 Copy-Item $coreNuspecPath $corePackagePath
-Copy-Item  $lightBlueDllPath $coreNet45LibPath
-Copy-Item  $lightBluePdbPath $coreNet45LibPath
+Copy-Item $lightBlueDllPath $coreNet45LibPath
+Copy-Item $lightBluePdbPath $coreNet45LibPath
 Copy-Item $linqpadEnvironmentTemplatePath $linqpadSamplesPath
 Copy-Item $linqpadIssueTemplatePath $linqpadSamplesPath
 
@@ -97,6 +107,12 @@ Copy-Item $multiHostExePath $toolsPath
 Copy-Item $multiHostDllPath $toolsPath
 Copy-Item $multiHostPdbPath $toolsPath
 Copy-Item $multiHostConfigPath $toolsPath
+Copy-Item $webServiceHostExePath $toolsPath
+Copy-Item $webServiceHostPdbPath $toolsPath
+Copy-Item $webServiceHostDllPath $toolsPath
+Copy-Item $workerServiceHostExePath $toolsPath
+Copy-Item $workerServiceHostPdbPath $toolsPath
+Copy-Item $workerServiceHostDllPath $toolsPath
 
 Push-Location -Path $corePackagePath
 

--- a/TestWebRole/Properties/AssemblyInfo.cs
+++ b/TestWebRole/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("TestWebRole")]
 [assembly: AssemblyDescription("Web role used for testing LightBlue functionality")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("Colin David Scott")]
 [assembly: AssemblyProduct("TestWebRole")]
 [assembly: AssemblyCopyright("Copyright © 2014-2015 LightBlue contributors")]
 [assembly: AssemblyTrademark("")]

--- a/TestWindsorRole/Properties/AssemblyInfo.cs
+++ b/TestWindsorRole/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("TestWindorRole")]
 [assembly: AssemblyDescription("Worker role used for testing Castle Windsor integration.")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("Colin David Scott")]
 [assembly: AssemblyProduct("TestWindorRole")]
 [assembly: AssemblyCopyright("Copyright © 2014-2015 LightBlue contributors")]
 [assembly: AssemblyTrademark("")]

--- a/TestWorkerRole/Properties/AssemblyInfo.cs
+++ b/TestWorkerRole/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("TestWorkerRole")]
 [assembly: AssemblyDescription("Worker role used for testing LightBlue functionality.")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("Colin David Scott")]
 [assembly: AssemblyProduct("TestWorkerRole")]
 [assembly: AssemblyCopyright("Copyright © 2014-2015 LightBlue contributors")]
 [assembly: AssemblyTrademark("")]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+version: 2.0.{build}
+pull_requests:
+  do_not_increment_build_number: true
+configuration: Release
+shallow_clone: true
+assembly_info:
+  patch: true
+  file: '**\AssemblyInfo.*'
+  assembly_version: '{version}'
+  assembly_file_version: '{version}'
+  assembly_informational_version: '{version}'
+nuget:
+  account_feed: true
+  project_feed: true
+before_build:
+- cmd: nuget restore
+build:
+  publish_nuget: true
+  include_nuget_references: true
+  verbosity: minimal
+deploy: off


### PR DESCRIPTION
Topshelf - An easy service hosting framework for building Windows services https://github.com/Topshelf/Topshelf

Set LightBlue.WorkerService or LightBlue.WebService as startup project and hit F5 to debug as a console application.

![image](https://cloud.githubusercontent.com/assets/2002649/19258975/dd4c8344-8faf-11e6-864f-e2c3a0a6591c.png)

OR

To run the windows service open a command prompt as administrator and pass the following arguments to the LightBlue.WebService or LightBlue.WorkerService executable.
- install
- start
- stop
- uninstall

![image](https://cloud.githubusercontent.com/assets/2002649/19259084/dc6f6ec2-8fb0-11e6-8cf9-1f0479bdea72.png)

![image](https://cloud.githubusercontent.com/assets/2002649/19259107/11f3635a-8fb1-11e6-9cee-a80ef21fcd5f.png)

**AppVeyor** https://ci.appveyor.com/project/Lightblue/lightblue

The Appveyor setup to build, test, and package LightBlue is configured from the .yml file in the root directory.    

![image](https://cloud.githubusercontent.com/assets/2002649/19425134/a4a8a228-9461-11e6-8a23-1785aff49465.png)

Each build produces these nuget package artifacts that need to be manually uploaded to nuget.org at this stage.

![image](https://cloud.githubusercontent.com/assets/2002649/19425003/a6357676-9460-11e6-96dc-1fb4494b8cae.png)
