### PR TITLE
Handle window service 'recycle'

### DIFF
--- a/LightBlue.WorkerService/Program.cs
+++ b/LightBlue.WorkerService/Program.cs
@@ -29,7 +29,9 @@ namespace LightBlue.WorkerService
                 x.EnableShutdown();
                 x.EnableServiceRecovery(rc =>
                 {
-                    rc.RestartService(1);
+                    rc.RestartService(0); // first failure
+                    rc.RestartService(0); // second failure
+                    rc.RestartService(0); // subsequent failures
                 });
             });
         }

--- a/LightBlue.WorkerService/WorkerHost.cs
+++ b/LightBlue.WorkerService/WorkerHost.cs
@@ -54,11 +54,11 @@ namespace LightBlue.WorkerService
                 try
                 {
                     _role.Run();
+                    Environment.Exit(0);
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
-                    Trace.TraceError("Worker host service errored with exception: {0}", ex);
-                    _hostControl.Restart();
+                    Environment.Exit(1);
                 }
             });
 


### PR DESCRIPTION
Perform service 'recycles' by setting up the recovery options to restart every time.
Explicitly exit the process if the role terminates or throws (when it's expected to keep running), which will then get restarted (as above).

Note: for the new recovery options to take effect, the service has to be uninstalled/deleted, then installed again with this new code.