### PR TITLE
Handle '.cscfg' or '.config' files

### DIFF
--- a/LightBlue.MultiHost/IISExpress/WebConfigHelper.cs
+++ b/LightBlue.MultiHost/IISExpress/WebConfigHelper.cs
@@ -15,7 +15,7 @@ namespace LightBlue.MultiHost.IISExpress
                 Port = int.Parse(config.Port),
                 RoleName = config.RoleName,
                 Title = config.Title,
-                ConfigurationPath = config.ConfigurationPath,
+                ConfigurationPath = ConfigurationLocator.LocateConfigurationFile(config.ConfigurationPath),
                 UseSsl = bool.Parse(config.UseSsl),
                 Hostname = config.Hostname,
                 UseHostedStorage = false,

--- a/LightBlue.MultiHost/Runners/RunnerFactory.cs
+++ b/LightBlue.MultiHost/Runners/RunnerFactory.cs
@@ -95,14 +95,14 @@ namespace LightBlue.MultiHost.Runners
             switch (isolation)
             {
                 case RoleIsolationMode.Thread:
-                    return new ThreadRunner(role, assemblyFilePath, config.ConfigurationPath, role.RoleName);
+                    return new ThreadRunner(role, assemblyFilePath, ConfigurationLocator.LocateConfigurationFile(config.ConfigurationPath), role.RoleName);
                 case RoleIsolationMode.AppDomain:
                     var setup = new AppDomainSetup
                     {
                         ApplicationBase = assemblyPath,
                         ConfigurationFile = config.Assembly + ".config",
                     };
-                    return new AppDomainRunner(role, setup, assemblyFilePath, config.ConfigurationPath, role.RoleName);
+                    return new AppDomainRunner(role, setup, assemblyFilePath, ConfigurationLocator.LocateConfigurationFile(config.ConfigurationPath), role.RoleName);
                 default:
                     throw new NotSupportedException();
             }

--- a/LightBlue.WebHost/LightBlue.WebHost.csproj
+++ b/LightBlue.WebHost/LightBlue.WebHost.csproj
@@ -52,6 +52,9 @@
     <Compile Include="..\LightBlue.Host\UnhandledExceptionBehaviour.cs">
       <Link>UnhandledExceptionBehaviour.cs</Link>
     </Compile>
+    <Compile Include="..\LightBlue\ConfigurationLocator.cs">
+      <Link>ConfigurationLocator.cs</Link>
+    </Compile>
     <Compile Include="..\LightBlue\Infrastructure\ExceptionExtensions.cs">
       <Link>ExceptionExtensions.cs</Link>
     </Compile>

--- a/LightBlue.WebHost/WebHostArgs.cs
+++ b/LightBlue.WebHost/WebHostArgs.cs
@@ -182,7 +182,7 @@ namespace LightBlue.WebHost
                 Title = string.IsNullOrWhiteSpace(title)
                     ? roleName
                     : title,
-                ConfigurationPath = configurationPath,
+                ConfigurationPath = ConfigurationLocator.LocateConfigurationFile(configurationPath),
                 UseSsl = useSsl.Value,
                 Hostname = hostname,
                 UseHostedStorage = useHostedStorage,

--- a/LightBlue/ConfigurationLocator.cs
+++ b/LightBlue/ConfigurationLocator.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.IO;
+
+namespace LightBlue
+{
+    // This is temporary
+    public static class ConfigurationLocator
+    {
+        public static string LocateConfigurationFile(string configurationPath)
+        {
+            var path = RemoveTrailingDoubleQuote(configurationPath);
+
+            if (File.Exists(path))
+            {
+                return path;
+            }
+
+            if (!Directory.Exists(path))
+            {
+                throw new ArgumentException(
+                    "The configuration path does not exist. Specify the specific configuration file or the directory in which ServiceConfiguration.Local.cscfg is located.");
+            }
+
+            var configurationFile = Path.Combine(path, "ServiceConfiguration.Local.cscfg");
+            if (!File.Exists(configurationFile))
+            {
+                throw new ArgumentException(
+                    "ServiceConfiguration.Local.cscfg cannot be located in the configuration path.");
+            }
+
+            return configurationFile;
+        }
+
+        private static string RemoveTrailingDoubleQuote(string configurationPath)
+        {
+            return configurationPath.EndsWith("\"")
+                ? configurationPath.Substring(0, configurationPath.Length - 1)
+                : configurationPath;
+        }
+    }
+}

--- a/LightBlue/LightBlue.csproj
+++ b/LightBlue/LightBlue.csproj
@@ -78,6 +78,7 @@
     <Compile Include="AzureEnvironment.cs" />
     <Compile Include="AzureEnvironmentSource.cs" />
     <Compile Include="BlobListing.cs" />
+    <Compile Include="ConfigurationLocator.cs" />
     <Compile Include="External\ExternalAzureSettings.cs" />
     <Compile Include="Hosted\HostedAzureBlobContainer.cs" />
     <Compile Include="Hosted\HostedAzureBlobDirectory.cs" />


### PR DESCRIPTION
Updated `StandaloneAzureSettings.cs` so it can parse cscfg and config files.
Brought back `ConfigurationLocator` so we don't have to update our AllServices.json configuration paths.