### PR TITLE
Store Assemblies Cache in Sub-folders using Config value

### DIFF
--- a/LightBlue.MultiHost/App.xaml.cs
+++ b/LightBlue.MultiHost/App.xaml.cs
@@ -93,7 +93,7 @@ namespace LightBlue.MultiHost
 
                     var assemblyLocations = query.ToArray();
 
-                    ThreadRunnerAssemblyCache.Initialise(assemblyLocations);
+                    ThreadRunnerAssemblyCache.Initialise(assemblyLocations, Configuration.AssemblyCacheId);
                     IisExpressHelper.KillIisExpressProcesses();
                     LightBlueConfiguration.SetAsMultiHost();
                 }

--- a/LightBlue.MultiHost/Configuration/MultiHostConfiguration.cs
+++ b/LightBlue.MultiHost/Configuration/MultiHostConfiguration.cs
@@ -4,6 +4,8 @@ namespace LightBlue.MultiHost.Configuration
 {
     public class MultiHostConfiguration
     {
+        // AssemblyCacheId is used to create an isolated cache for each system which allows for MultiHost to run multiple systems on the same machine
+        public string AssemblyCacheId { get; set; } = "LightBlue.MultiHost";
         public IEnumerable<RoleConfiguration> Roles { get; set; }
 
         public MultiHostConfiguration()

--- a/LightBlue.MultiHost/Runners/ThreadRunnerAssemblyCache.cs
+++ b/LightBlue.MultiHost/Runners/ThreadRunnerAssemblyCache.cs
@@ -8,10 +8,13 @@ namespace LightBlue.MultiHost.Runners
 {
     static class ThreadRunnerAssemblyCache
     {
-        public static readonly string AssemblyCacheFolder = Path.Combine(Path.GetTempPath(), "LightBlue.MultiHost.AssemblyCache");
+        public static string AssemblyCacheFolder { get; private set; } = Path.Combine(Path.GetTempPath(), "LightBlue.MultiHost.AssemblyCache");
 
-        public static void Initialise(IEnumerable<string> assemblyLocations)
+        public static void Initialise(IEnumerable<string> assemblyLocations, string assemblyCacheId)
         {
+            var systemCacheFolder = Path.Combine(AssemblyCacheFolder, assemblyCacheId);
+            AssemblyCacheFolder = systemCacheFolder;
+
             if (Directory.Exists(AssemblyCacheFolder))
             {
                 foreach (var f in Directory.EnumerateFiles(AssemblyCacheFolder))


### PR DESCRIPTION
Multiple LightBlue.MultiHost's cannot currently be ran simultaneously due to the fact that we clear the Assembly Cache each time MultiHost starts up. 
To resolve this, I have added a new "AssemblyCacheId" property to the configuration which will be used to isolate the assembly caches based on what this ID is.

AssemblyCacheFolder is also no longer readonly as we will add the AssemblyCacheId subfolder to the path on Initialisation 
