### PR TITLE
Net48 process isolation

### DIFF
--- a/LightBlue.MultiHost/Configuration/MultiHostConfiguration.cs
+++ b/LightBlue.MultiHost/Configuration/MultiHostConfiguration.cs
@@ -7,6 +7,9 @@ namespace LightBlue.MultiHost.Configuration
         // AssemblyCacheId is used to create an isolated cache for each system which allows for MultiHost to run multiple systems on the same machine
         public string AssemblyCacheId { get; set; } = "LightBlue.MultiHost";
         public IEnumerable<RoleConfiguration> Roles { get; set; }
+        public int ThreadDelayMs { get; set; } = 50;
+        public int AppDomainDelayMs { get; set; } = 50;
+        public int ProcessDelayMs { get; set; } = 500;  // longer delay for process isolation
 
         public MultiHostConfiguration()
         {

--- a/LightBlue.MultiHost/Configuration/MultiHostConfigurationService.cs
+++ b/LightBlue.MultiHost/Configuration/MultiHostConfigurationService.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
@@ -20,6 +19,9 @@ namespace LightBlue.MultiHost.Configuration
             // This model ensures that we don't persist web related configuration into standard (worker) roles
             var persistanceModel = new
             {
+                multiHostConfiguration.ThreadDelayMs,
+                multiHostConfiguration.AppDomainDelayMs,
+                multiHostConfiguration.ProcessDelayMs,
                 Roles = from x in multiHostConfiguration.Roles
                         let isWorker = string.IsNullOrWhiteSpace(x.Port)
                         select isWorker
@@ -32,6 +34,7 @@ namespace LightBlue.MultiHost.Configuration
                                 x.ConfigurationPath,
                                 
                                 x.RoleIsolationMode,
+                                x.ProcessPriority,
                             }
                             : (dynamic)new
                             {
@@ -46,13 +49,14 @@ namespace LightBlue.MultiHost.Configuration
                                 x.Hostname,
 
                                 x.RoleIsolationMode,
+                                x.ProcessPriority,
                             }
             };
 
             using (var fs = new FileStream(path, FileMode.Truncate, FileAccess.Write))
             using (var sw = new StreamWriter(fs))
             {
-                sw.WriteLine(JsonSerializer.Serialize(persistanceModel, new JsonSerializerOptions { WriteIndented = true }));
+                sw.WriteLine(JsonSerializer.Serialize(persistanceModel, new JsonSerializerOptions { WriteIndented = true, IgnoreNullValues = true }));
             }
         }
     }

--- a/LightBlue.MultiHost/Configuration/RoleConfiguration.cs
+++ b/LightBlue.MultiHost/Configuration/RoleConfiguration.cs
@@ -16,5 +16,6 @@
 
         // optional for all roles
         public string RoleIsolationMode { get; set; }
+        public string ProcessPriority { get; set; }
     }
 }

--- a/LightBlue.MultiHost/EditRoleView.xaml
+++ b/LightBlue.MultiHost/EditRoleView.xaml
@@ -36,6 +36,7 @@
                 <Label Grid.Row="6" Grid.Column="0" Content="UseSsl:"/>
                 <Label Grid.Row="7" Grid.Column="0" Content="Hostname:"/>
                 <Label Grid.Row="8" Grid.Column="0" Content="RoleIsolationMode:"/>
+                <Label Grid.Row="9" Grid.Column="0" Content="ProcessPriority:"/>
 
                 <CheckBox Grid.Row="0" Grid.Column="1" Margin="3"  IsChecked="{Binding RoleConfiguration.EnabledOnStartup}"/>
 
@@ -57,8 +58,14 @@
 
                 <ComboBox Grid.Row="8" Grid.Column="1" Margin="3" 
                           DisplayMemberPath="DisplayName" 
-                          ItemsSource="{multiHost:EnumToItemsSource {x:Type enums: RoleIsolationMode}}"
+                          ItemsSource="{multiHost:EnumToItemsSource {x:Type enums:RoleIsolationMode}}"
                           SelectedValue="{Binding Path=RoleConfiguration.RoleIsolationMode, Mode=TwoWay}"
+                          SelectedValuePath="Value"/>
+
+                <ComboBox Grid.Row="9" Grid.Column="1" Margin="3" 
+                          DisplayMemberPath="DisplayName" 
+                          ItemsSource="{multiHost:EnumToItemsSource {x:Type enums:ProcessPriority}}"
+                          SelectedValue="{Binding Path=RoleConfiguration.ProcessPriority, Mode=TwoWay}"
                           SelectedValuePath="Value"/>
             </Grid>
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">

--- a/LightBlue.MultiHost/EditRoleView.xaml
+++ b/LightBlue.MultiHost/EditRoleView.xaml
@@ -62,8 +62,8 @@
                           SelectedValuePath="Value"/>
             </Grid>
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                <Button x:Name="BtnOk" Margin="3" Content="Save" Width="100" Height="30" Style="{StaticResource AccentedSquareButtonStyle}" Click="OkButton_Click" HorizontalAlignment="Right"/>
-                <Button x:Name="BtnCancel" Margin="3" Content="Cancel" Width="100" Height="30" Style="{StaticResource AccentedSquareButtonStyle}" Click="CancelButton_Click" HorizontalAlignment="Right" />
+                <Button x:Name="BtnOk" Margin="3" Content="Save" Width="100" Height="30" Style="{StaticResource MahApps.Styles.Button.Square.Accent}" Click="OkButton_Click" HorizontalAlignment="Right"/>
+                <Button x:Name="BtnCancel" Margin="3" Content="Cancel" Width="100" Height="30" Style="{StaticResource MahApps.Styles.Button.Square.Accent}" Click="CancelButton_Click" HorizontalAlignment="Right" />
             </StackPanel>
         </StackPanel>
     </Grid>

--- a/LightBlue.MultiHost/MainWindow.xaml.cs
+++ b/LightBlue.MultiHost/MainWindow.xaml.cs
@@ -2,18 +2,17 @@
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Media;
 using LightBlue.MultiHost.Configuration;
 using LightBlue.MultiHost.Controls;
+using LightBlue.MultiHost.Runners;
 using LightBlue.MultiHost.ViewModel;
 
 namespace LightBlue.MultiHost
@@ -109,7 +108,9 @@ namespace LightBlue.MultiHost
             DataContext = this;
 
             var autos = Services.Where(x => x.Status == RoleStatus.Sequenced).ToArray();
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             BeginAutoStart(autos);
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
 
             Loaded += (s, a) =>
             {
@@ -144,10 +145,39 @@ namespace LightBlue.MultiHost
             }
         }
 
-        async void BeginAutoStart(Role[] roles)
+        private async Task BeginAutoStart(Role[] roles)
         {
-            await Task.Delay(TimeSpan.FromSeconds(0.2));
-            foreach (var r in roles) r.StartAutomatically();
+            var rolesByIsolationMode = roles.GroupBy(x => x.IsolationMode).ToDictionary(x => x.Key, x => x);
+
+            if (rolesByIsolationMode.ContainsKey(RoleIsolationMode.Thread))
+            {
+                await AutoStartRoleBatch(
+                    roles: rolesByIsolationMode[RoleIsolationMode.Thread],
+                    perRoleDelay: TimeSpan.FromMilliseconds(App.Configuration.ThreadDelayMs));
+            }
+
+            if (rolesByIsolationMode.ContainsKey(RoleIsolationMode.AppDomain))
+            {
+                await AutoStartRoleBatch(
+                    roles: rolesByIsolationMode[RoleIsolationMode.AppDomain],
+                    perRoleDelay: TimeSpan.FromMilliseconds(App.Configuration.AppDomainDelayMs));
+            }
+
+            if (rolesByIsolationMode.ContainsKey(RoleIsolationMode.Process))
+            {
+                await AutoStartRoleBatch(
+                    roles: rolesByIsolationMode[RoleIsolationMode.Process],
+                    perRoleDelay: TimeSpan.FromMilliseconds(App.Configuration.ProcessDelayMs));
+            }
+        }
+
+        private async Task AutoStartRoleBatch(IGrouping<RoleIsolationMode, Role> roles, TimeSpan perRoleDelay)
+        {
+            foreach (var role in roles)
+            {
+                await Task.Delay(perRoleDelay);
+                role.StartAutomatically();
+            }
         }
 
         bool CollectionViewSource_Filter(object item)

--- a/LightBlue.MultiHost/MainWindow.xaml.cs
+++ b/LightBlue.MultiHost/MainWindow.xaml.cs
@@ -157,7 +157,7 @@ namespace LightBlue.MultiHost
             var r = (Role) item;
             var filter = r.Title.ToLowerInvariant().Contains(_searchText.ToLowerInvariant())
                          || r.Status.ToString().ToLowerInvariant().Contains(_searchText.ToLowerInvariant())
-                         || r.RoleName.ToLowerInvariant().Contains(_searchText.ToLowerInvariant());
+                         || (r.RoleName?.ToLowerInvariant().Contains(_searchText.ToLowerInvariant()) ?? false);
             return filter;
         }
 

--- a/LightBlue.MultiHost/MultiHostProcess.cs
+++ b/LightBlue.MultiHost/MultiHostProcess.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace LightBlue.MultiHost
+{
+    public class MultiHostProcess
+    {
+        private static readonly Lazy<MultiHostProcess> _instance = new Lazy<MultiHostProcess>(() => new MultiHostProcess());
+        public static MultiHostProcess Job => _instance.Value;
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern IntPtr CreateJobObject(IntPtr lpJobAttributes, string lpName);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool SetInformationJobObject(IntPtr hJob, JobObjectInfoType infoType, IntPtr lpJobObjectInfo, uint cbJobObjectInfoLength);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool AssignProcessToJobObject(IntPtr job, IntPtr process);
+
+        private readonly IntPtr _job;
+        private MultiHostProcess()
+        {
+            _job = CreateJobObject(IntPtr.Zero, null);
+
+            var info = new JOBOBJECT_EXTENDED_LIMIT_INFORMATION();
+            info.BasicLimitInformation.LimitFlags = 0x2000; // JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+
+            int length = Marshal.SizeOf(typeof(JOBOBJECT_EXTENDED_LIMIT_INFORMATION));
+            IntPtr extendedInfoPtr = Marshal.AllocHGlobal(length);
+            Marshal.StructureToPtr(info, extendedInfoPtr, false);
+
+            SetInformationJobObject(_job, JobObjectInfoType.ExtendedLimitInformation, extendedInfoPtr, (uint)length);
+
+            Marshal.FreeHGlobal(extendedInfoPtr);
+        }
+
+        public void AddProcess(Process process)
+        {
+            AssignProcessToJobObject(_job, process.Handle);
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct JOBOBJECT_BASIC_LIMIT_INFORMATION
+        {
+            public long PerProcessUserTimeLimit;
+            public long PerJobUserTimeLimit;
+            public uint LimitFlags;
+            public UIntPtr MinimumWorkingSetSize;
+            public UIntPtr MaximumWorkingSetSize;
+            public uint ActiveProcessLimit;
+            public IntPtr Affinity;
+            public uint PriorityClass;
+            public uint SchedulingClass;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct IO_COUNTERS
+        {
+            public ulong ReadOperationCount;
+            public ulong WriteOperationCount;
+            public ulong OtherOperationCount;
+            public ulong ReadTransferCount;
+            public ulong WriteTransferCount;
+            public ulong OtherTransferCount;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+        {
+            public JOBOBJECT_BASIC_LIMIT_INFORMATION BasicLimitInformation;
+            public IO_COUNTERS IoInfo;
+            public UIntPtr ProcessMemoryLimit;
+            public UIntPtr JobMemoryLimit;
+            public UIntPtr PeakProcessMemoryUsed;
+            public UIntPtr PeakJobMemoryUsed;
+        }
+
+        private enum JobObjectInfoType
+        {
+            AssociateCompletionPortInformation = 7,
+            BasicLimitInformation = 2,
+            BasicUIRestrictions = 4,
+            EndOfJobTimeInformation = 6,
+            ExtendedLimitInformation = 9,
+            SecurityLimitInformation = 5,
+            GroupInformation = 11
+        }
+    }
+}

--- a/LightBlue.MultiHost/RoleExtensions.cs
+++ b/LightBlue.MultiHost/RoleExtensions.cs
@@ -17,6 +17,7 @@ namespace LightBlue.MultiHost
                 WorkingDirectory = Path.GetDirectoryName(role.Config.ConfigurationPath)
             };
 
+            psi.EnvironmentVariables.Add("LightBlueRunMode", "process");
             psi.EnvironmentVariables.Add("LightBlueHost", "true");
             psi.EnvironmentVariables.Add("LightBlueConfigurationPath", role.Config.ConfigurationPath);
             psi.EnvironmentVariables.Add("LightBlueRoleName", role.Config.RoleName);

--- a/LightBlue.MultiHost/Runners/AzureFunctionRunner.cs
+++ b/LightBlue.MultiHost/Runners/AzureFunctionRunner.cs
@@ -53,6 +53,8 @@ namespace LightBlue.MultiHost.Runners
             _parent.Start();
             _parent.BeginOutputReadLine();
             _parent.BeginErrorReadLine();
+            _parent.SetPriority(_role);
+            _parent.AllocateToMultiHostProcess();
 
             _started.SetResult(new object());
 

--- a/LightBlue.MultiHost/Runners/DotNetFrameworkRunner.cs
+++ b/LightBlue.MultiHost/Runners/DotNetFrameworkRunner.cs
@@ -47,6 +47,8 @@ namespace LightBlue.MultiHost.Runners
             _parent.Start();
             _parent.BeginOutputReadLine();
             _parent.BeginErrorReadLine();
+            _parent.SetPriority(_role);
+            _parent.AllocateToMultiHostProcess();
 
             _started.SetResult(new object());
 

--- a/LightBlue.MultiHost/Runners/IisExpressRunner.cs
+++ b/LightBlue.MultiHost/Runners/IisExpressRunner.cs
@@ -40,6 +40,8 @@ namespace LightBlue.MultiHost.Runners
                 if (_process.Start())
                 {
                     _role.TraceWriteLine(Identifier, "Website started in new IISExpress process: " + _process.Id);
+                    _process.SetPriority(_role);
+                    _process.AllocateToMultiHostProcess();
                 }
                 else
                 {
@@ -61,7 +63,8 @@ namespace LightBlue.MultiHost.Runners
             if (File.Exists(@"c:\\windows\\system32\\vsjitdebugger.exe"))
             {
                 var psi = new ProcessStartInfo(@"c:\\windows\\system32\\vsjitdebugger.exe", "-p " + _process.Id);
-                Process.Start(psi);
+                var process = Process.Start(psi);
+                MultiHostProcess.Job.AddProcess(process);
                 return true;
             }
             return false;

--- a/LightBlue.MultiHost/Runners/NpmRunner.cs
+++ b/LightBlue.MultiHost/Runners/NpmRunner.cs
@@ -52,6 +52,8 @@ namespace LightBlue.MultiHost.Runners
             _parent.Start();
             _parent.BeginOutputReadLine();
             _parent.BeginErrorReadLine();
+            _parent.SetPriority(_role);
+            _parent.AllocateToMultiHostProcess();
 
             _started.SetResult(new object());
 

--- a/LightBlue.MultiHost/Runners/ProcessExtensions.cs
+++ b/LightBlue.MultiHost/Runners/ProcessExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using LightBlue.MultiHost.ViewModel;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Management;
@@ -12,6 +13,28 @@ namespace LightBlue.MultiHost.Runners
             var query = $"Select * From Win32_Process Where ParentProcessID={process.Id}";
             foreach (var mo in new ManagementObjectSearcher(query).Get())
                 yield return Process.GetProcessById(Convert.ToInt32(mo["ProcessID"]));
+        }
+
+        public static void AllocateToMultiHostProcess(this Process process)
+        {
+            // Allows windows to clean up child process for us when the parent process is killed
+            MultiHostProcess.Job.AddProcess(process);
+        }
+
+        public static void SetPriority(this Process process, Role role)
+        {
+            switch (role.ProcessPriority)
+            {
+                case ProcessPriority.BelowNormal:
+                    process.PriorityClass = ProcessPriorityClass.BelowNormal;
+                    break;
+                case ProcessPriority.Normal:
+                    process.PriorityClass = ProcessPriorityClass.Normal;
+                    break;
+                case ProcessPriority.AboveNormal:
+                    process.PriorityClass = ProcessPriorityClass.AboveNormal;
+                    break;
+            }
         }
     }
 }

--- a/LightBlue.MultiHost/Runners/ProcessPriority.cs
+++ b/LightBlue.MultiHost/Runners/ProcessPriority.cs
@@ -1,0 +1,9 @@
+namespace LightBlue.MultiHost.Runners
+{
+    public enum ProcessPriority
+    {
+        BelowNormal,
+        Normal,
+        AboveNormal
+    }
+}

--- a/LightBlue.MultiHost/Runners/RunnerFactory.cs
+++ b/LightBlue.MultiHost/Runners/RunnerFactory.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using LightBlue.MultiHost.IISExpress;
 using LightBlue.MultiHost.ViewModel;
 
 namespace LightBlue.MultiHost.Runners
@@ -75,6 +74,8 @@ namespace LightBlue.MultiHost.Runners
                         ConfigurationFile = config.Assembly + ".config",
                     };
                     return new AppDomainRunner(role, setup, assemblyFilePath, ConfigurationLocator.LocateConfigurationFile(config.ConfigurationPath), role.RoleName);
+                case RoleIsolationMode.Process:
+                    return new DotNetFrameworkRunner(role);
                 default:
                     throw new NotSupportedException();
             }

--- a/LightBlue.MultiHost/ViewModel/Role.cs
+++ b/LightBlue.MultiHost/ViewModel/Role.cs
@@ -50,6 +50,16 @@ namespace LightBlue.MultiHost.ViewModel
             }
         }
 
+        public ProcessPriority ProcessPriority
+        {
+            get
+            {
+                return string.IsNullOrWhiteSpace(Config.ProcessPriority)
+                    ? ProcessPriority.BelowNormal
+                    : (ProcessPriority)Enum.Parse(typeof(ProcessPriority), Config.ProcessPriority);
+            }
+        }
+
         public string ImageSource
         {
             get


### PR DESCRIPTION
- Catch all for RoleName can run in net48 Process isolation
- Services have a slight delay between startups to prevent overloading your computer
  - Longer delay between Process isolated services as that was the primary culprit
- Serialized config (the json files) now ignore nulls on save
- NetCore apps can now be run with a .dll, .exe, or project directory (using .dll is the fastest)
- Process isolated services 
  - Are now "children" of the MultiHost process so Windows will correctly kill them when you close the MultiHost
  - Are defaulted to run with "BelowNormal" priority but that can be overridden with a "ProcessPriority" setting per role
- Fixed a bug with the filter if RoleName was null
- Fixed missing button style

Ideally, `BeginAutoStart(autos);` should have its continuations on a background thread as the UI locks up as the Roles are started. I didn't dig into the issue too much as there are PropertyChangeNotifications happening that update the UI and would need to be re-scheduled back onto the UI thread.