### PR TITLE
Add Custom Runner

### DIFF
--- a/LightBlue.MultiHost/Configuration/CustomRunnerConfiguration.cs
+++ b/LightBlue.MultiHost/Configuration/CustomRunnerConfiguration.cs
@@ -1,0 +1,13 @@
+using System.Text.Json.Serialization;
+
+namespace LightBlue.MultiHost.Configuration
+{
+    public class CustomRunnerConfiguration
+    {
+        public string Name { get; set; }
+        public string Command { get; set; }
+        public string Arguments { get; set; } = string.Empty;
+        [JsonConverter(typeof(IconOptionConverter))]
+        public IconOption Icon { get; set; } = IconOption.Worker;
+    }
+}

--- a/LightBlue.MultiHost/Configuration/IconHelper.cs
+++ b/LightBlue.MultiHost/Configuration/IconHelper.cs
@@ -4,7 +4,7 @@ namespace LightBlue.MultiHost.Configuration
 {
     public static class IconHelper
     {
-        public static readonly Dictionary<IconOption, string> IconPaths = new Dictionary<IconOption, string>()
+        public static readonly IReadOnlyDictionary<IconOption, string> IconPaths = new Dictionary<IconOption, string>()
         {
             [IconOption.Website] = @"Resources\website.ico",
             [IconOption.ReadModelPopulator] = @"Resources\readmodelpopulator.ico",

--- a/LightBlue.MultiHost/Configuration/IconHelper.cs
+++ b/LightBlue.MultiHost/Configuration/IconHelper.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+
+namespace LightBlue.MultiHost.Configuration
+{
+    public static class IconHelper
+    {
+        public static readonly Dictionary<IconOption, string> IconPaths = new Dictionary<IconOption, string>()
+        {
+            [IconOption.Website] = @"Resources\website.ico",
+            [IconOption.ReadModelPopulator] = @"Resources\readmodelpopulator.ico",
+            [IconOption.ProcessManager] = @"Resources\processmanager.ico",
+            [IconOption.MessageHub] = @"Resources\messagehub.ico",
+            [IconOption.DomainService] = @"Resources\domainservice.ico",
+            [IconOption.Debug] = @"Resources\debug.ico",
+            [IconOption.Worker] = @"Resources\worker.ico"
+        };
+
+        public static IconOption RoleToIconOption(RoleConfiguration config)
+        {
+            switch (config.RoleName)
+            {
+                case "ReadModelPopulator":
+                    return IconOption.ReadModelPopulator;
+                case "CommandProcessor":
+                    return IconOption.DomainService;
+                case "ProcessManager":
+                    return IconOption.ProcessManager;
+                case "AzureFunction":
+                case "Npm":
+                    return IconOption.Website;
+                case "WebRole":
+                    return config.Title.Contains("Hub") 
+                    ? IconOption.MessageHub
+                    : IconOption.Website;
+                default:
+                    return IconOption.Worker;            
+            }
+        }
+    }
+}

--- a/LightBlue.MultiHost/Configuration/IconOption.cs
+++ b/LightBlue.MultiHost/Configuration/IconOption.cs
@@ -1,0 +1,13 @@
+namespace LightBlue.MultiHost.Configuration
+{
+    public enum IconOption
+    {
+        Worker = 0,
+        Website = 1,
+        ReadModelPopulator = 2,
+        ProcessManager = 3,
+        MessageHub = 4,
+        DomainService = 5,
+        Debug = 6,
+    }
+}

--- a/LightBlue.MultiHost/Configuration/IconOptionConverter.cs
+++ b/LightBlue.MultiHost/Configuration/IconOptionConverter.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace LightBlue.MultiHost.Configuration
+{
+    // Allows for the use of either the enum name or the integer value in JSON serialization/deserialization
+    public class IconOptionConverter : JsonConverter<IconOption>
+    {
+        public override IconOption Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.Number)
+            {
+                return (IconOption)reader.GetInt32();
+            }
+
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                var value = reader.GetString();
+                if (Enum.TryParse(value, true, out IconOption result))
+                {
+                    return result;
+                }
+            }
+
+            return default;
+        }
+
+        public override void Write(Utf8JsonWriter writer, IconOption value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value.ToString());
+        }
+    }
+}

--- a/LightBlue.MultiHost/Configuration/MultiHostConfiguration.cs
+++ b/LightBlue.MultiHost/Configuration/MultiHostConfiguration.cs
@@ -4,6 +4,7 @@ namespace LightBlue.MultiHost.Configuration
 {
     public class MultiHostConfiguration
     {
+        public IEnumerable<CustomRunnerConfiguration> CustomRunners { get; set; } = new List<CustomRunnerConfiguration>();
         // AssemblyCacheId is used to create an isolated cache for each system which allows for MultiHost to run multiple systems on the same machine
         public string AssemblyCacheId { get; set; } = "LightBlue.MultiHost";
         public IEnumerable<RoleConfiguration> Roles { get; set; }

--- a/LightBlue.MultiHost/Configuration/MultiHostConfigurationService.cs
+++ b/LightBlue.MultiHost/Configuration/MultiHostConfigurationService.cs
@@ -19,6 +19,8 @@ namespace LightBlue.MultiHost.Configuration
             // This model ensures that we don't persist web related configuration into standard (worker) roles
             var persistanceModel = new
             {
+                multiHostConfiguration.CustomRunners,
+                multiHostConfiguration.AssemblyCacheId,
                 multiHostConfiguration.ThreadDelayMs,
                 multiHostConfiguration.AppDomainDelayMs,
                 multiHostConfiguration.ProcessDelayMs,

--- a/LightBlue.MultiHost/Runners/CustomRunner.cs
+++ b/LightBlue.MultiHost/Runners/CustomRunner.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using LightBlue.MultiHost.Configuration;
+using LightBlue.MultiHost.ViewModel;
+
+namespace LightBlue.MultiHost.Runners
+{
+    public class CustomRunner : IRunner
+    {
+        private readonly Role _role;
+
+        public string Identifier { get; }
+
+        public Task Started => _started.Task;
+        public Task Completed => _completed.Task;
+
+        private readonly TaskCompletionSource<object> _started = new TaskCompletionSource<object>();
+        private readonly TaskCompletionSource<object> _completed = new TaskCompletionSource<object>();
+        private Process _parent;
+
+        private readonly CustomRunnerConfiguration _config;
+
+        public CustomRunner(CustomRunnerConfiguration config, Role role)
+        {
+            Identifier = role.RoleName;
+
+            _role = role;
+            _config = config;
+        }
+
+        public void Start()
+        {
+            _parent = _role.NewDefaultProcess(_config.Command, CreateArguments(_config.Arguments));
+
+            _parent.OutputDataReceived += (_, args) =>
+            {
+                if (!string.IsNullOrWhiteSpace(args.Data))
+                    _role.TraceWriteLine(Identifier, args.Data);
+            };
+            _parent.ErrorDataReceived += (_, args) =>
+            {
+                if (!string.IsNullOrWhiteSpace(args.Data))
+                    _role.TraceWriteLine(Identifier, args.Data);
+            };
+            _parent.Exited += (s, e) =>
+            {
+                _role.TraceWriteLine(Identifier, $"Parent process {_role.RoleName} exited");
+                _completed.SetResult(new object());
+            };
+
+            _parent.Start();
+            _parent.BeginOutputReadLine();
+            _parent.BeginErrorReadLine();
+            _parent.SetPriority(_role);
+            _parent.AllocateToMultiHostProcess();
+
+            _started.SetResult(new object());
+
+            _role.TraceWriteLine(Identifier, $"Process {_parent.Id} {_parent.ProcessName} {_parent.StartInfo.Arguments} {_parent.StartInfo.WorkingDirectory} started");
+        }
+
+        public void Dispose()
+        {
+            foreach (var c in _parent.GetChildren())
+            {
+                if (!c.HasExited)
+                {
+                    _role.TraceWriteLine(Identifier, $"Kill child process {c.Id} {c.ProcessName}");
+                    c.Kill();
+                }
+            }
+
+            if (!_parent.HasExited)
+            {
+                _role.TraceWriteLine(Identifier, $"Kill parent process {_parent.Id} {_parent.ProcessName} {_parent.StartInfo.Arguments} {_parent.StartInfo.WorkingDirectory}");
+                _parent.Kill();
+            }
+        }
+
+        private string CreateArguments(string args)
+        {
+            if (string.IsNullOrWhiteSpace(args))
+                return string.Empty;
+
+            if (args.Contains("{port}"))
+                args = args
+                    .Replace("{port}", _role.Config.Port.ToString());
+
+            return args;
+        }
+    }
+}

--- a/LightBlue.MultiHost/Runners/RoleRunner.cs
+++ b/LightBlue.MultiHost/Runners/RoleRunner.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading.Tasks;
+using LightBlue.MultiHost.Configuration;
 using LightBlue.MultiHost.ViewModel;
 
 namespace LightBlue.MultiHost.Runners
@@ -46,6 +47,14 @@ namespace LightBlue.MultiHost.Runners
 
         public void Start()
         {
+            if (App.Configuration.CustomRunners.FirstOrDefault(x => x.Name == _role.RoleName) is CustomRunnerConfiguration customRunner)
+            {
+                var role = RunnerFactory.CreateCustomRunner(customRunner, _role);
+                _resources.Add(role);
+                role.Start();
+                return;
+            }
+
             if (_role.RoleName == "DotNetCore")
             {
                 var role = RunnerFactory.CreateDotNetCoreRunner(_role);

--- a/LightBlue.MultiHost/Runners/RunnerFactory.cs
+++ b/LightBlue.MultiHost/Runners/RunnerFactory.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using LightBlue.MultiHost.Configuration;
 using LightBlue.MultiHost.ViewModel;
 
 namespace LightBlue.MultiHost.Runners
@@ -99,6 +100,11 @@ namespace LightBlue.MultiHost.Runners
         public static IRunner CreateAzureFunctionRunner(Role role)
         {
             return new AzureFunctionRunner(role);
+        }
+
+        public static IRunner CreateCustomRunner(CustomRunnerConfiguration customRunner, Role role)
+        {
+            return new CustomRunner(customRunner, role);
         }
     }
 }

--- a/LightBlue.MultiHost/ViewModel/Role.cs
+++ b/LightBlue.MultiHost/ViewModel/Role.cs
@@ -64,24 +64,11 @@ namespace LightBlue.MultiHost.ViewModel
         {
             get
             {
-                // TODO: drive this from configuration
-                switch (Config.RoleName)
-                {
-                    case "ReadModelPopulator":
-                        return @"Resources\readmodelpopulator.ico";
-                    case "CommandProcessor":
-                        return @"Resources\domainservice.ico";
-                    case "ProcessManager":
-                        return @"Resources\processmanager.ico";
-                    case "AzureFunction":
-                    case "Npm":
-                    case "WebRole":
-                        return Config.Title.Contains("Hub")
-                            ? @"Resources\messagehub.ico"
-                            : @"Resources\website.ico";
-                    default:
-                        return @"Resources\worker.ico";
-                }
+                var iconOption = App.Configuration.CustomRunners.FirstOrDefault(x => x.Name == Config.RoleName) is CustomRunnerConfiguration customRunner
+                    ? customRunner.Icon
+                    : IconHelper.RoleToIconOption(Config);
+
+                return IconHelper.IconPaths[iconOption];
             }
         }
 


### PR DESCRIPTION
By adding custom runners, you can run pretty much anything in LightBlue MultiHost without the need to add a new runner specifically for what you're trying to run. Eg. AzureFunction and NPM runners.

I havent removed any Runners in this PR but as an example, we could remove the AzureFunction runner and then the user could use a Custom Runner like
```json
"CustomRunners": [
  {
        "Name": "FunctionApp",
        "Command": "C:\\Program Files\\Microsoft\\Azure Functions Core Tools\\func.exe",
        "Arguments": "start --port {port}",
        "Icon": "processmanager"
  }
],
"Roles": [
    {
      "EnabledOnStartup": true,
      "Assembly": "",
      "RoleName": "FunctionApp",
      "Title": "My Function App",
      "Port": "5000"
      "ConfigurationPath": "C:\\source\\MyFunctionApp"
    }
]
```