### PR TITLE
fix: Fix IIS Logging

### DIFF
--- a/LightBlue.MultiHost/IISExpress/Configuration.template
+++ b/LightBlue.MultiHost/IISExpress/Configuration.template
@@ -163,7 +163,7 @@
                 </bindings>
             </site>
             <siteDefaults>
-                <logFile logFormat="W3C" directory="%IIS_USER_HOME%\Logs" />
+                <logFile logFormat="W3C" directory="%IIS_USER_HOME%\Logs\__HOSTNAME__"/>
                 <traceFailedRequestsLogging directory="%IIS_USER_HOME%\TraceLogFiles" enabled="false" maxLogFileSizeKB="1024" />
             </siteDefaults>
             <applicationDefaults applicationPool="IISExpressAppPool" />


### PR DESCRIPTION
- The IIS hosted applications aren't logging to the same file so only 1 sites gets logged.
- Added the hostname to the logging path to ensure all applications get a log file