### PR TITLE
feat: separate role and runner

### DIFF
--- a/LightBlue.MultiHost/Configuration/CustomRunnerConfiguration.cs
+++ b/LightBlue.MultiHost/Configuration/CustomRunnerConfiguration.cs
@@ -1,13 +1,14 @@
-using System.Text.Json.Serialization;
-
 namespace LightBlue.MultiHost.Configuration
 {
+    /// <summary>
+    /// Allows users to BYO runner, string matches
+    /// the name of the configured Runner against the 
+    /// Runner specified in the Service
+    /// </summary>
     public class CustomRunnerConfiguration
     {
-        public string Name { get; set; }
+        public string RunnerName { get; set; }
         public string Command { get; set; }
         public string Arguments { get; set; } = string.Empty;
-        [JsonConverter(typeof(IconOptionConverter))]
-        public IconOption Icon { get; set; } = IconOption.Worker;
     }
 }

--- a/LightBlue.MultiHost/Configuration/IRoleConfiguationService.cs
+++ b/LightBlue.MultiHost/Configuration/IRoleConfiguationService.cs
@@ -2,6 +2,6 @@ namespace LightBlue.MultiHost.Configuration
 {
     public interface IRoleConfiguationService
     {
-        RoleConfiguration Edit(string serviceTitle, string multiHostConfigurationFilePath);
+        ServiceConfiguration Edit(string serviceTitle, string multiHostConfigurationFilePath);
     }
 }

--- a/LightBlue.MultiHost/Configuration/IconHelper.cs
+++ b/LightBlue.MultiHost/Configuration/IconHelper.cs
@@ -15,7 +15,7 @@ namespace LightBlue.MultiHost.Configuration
             [IconOption.Worker] = @"Resources\worker.ico"
         };
 
-        public static IconOption RoleToIconOption(RoleConfiguration config)
+        public static IconOption RoleToIconOption(ServiceConfiguration config)
         {
             switch (config.RoleName)
             {

--- a/LightBlue.MultiHost/Configuration/MultiHostConfiguration.cs
+++ b/LightBlue.MultiHost/Configuration/MultiHostConfiguration.cs
@@ -1,20 +1,76 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 
 namespace LightBlue.MultiHost.Configuration
 {
     public class MultiHostConfiguration
     {
+        /// <summary>
+        /// Jargon:
+        /// Service = an instance of proccessing
+        /// Role = a type/category of service
+        /// Runner = how a service is executed
+        /// </summary>
+        /// 
+        public int ServiceBootRateLimitMs { get; set; } = 10;
+        public string AssemblyCacheId { get; set; } = "LightBlue.MultiHost";
         public IEnumerable<CustomRunnerConfiguration> CustomRunners { get; set; } = new List<CustomRunnerConfiguration>();
         // AssemblyCacheId is used to create an isolated cache for each system which allows for MultiHost to run multiple systems on the same machine
-        public string AssemblyCacheId { get; set; } = "LightBlue.MultiHost";
-        public IEnumerable<RoleConfiguration> Roles { get; set; }
-        public int ThreadDelayMs { get; set; } = 50;
-        public int AppDomainDelayMs { get; set; } = 50;
-        public int ProcessDelayMs { get; set; } = 500;  // longer delay for process isolation
+        public IEnumerable<RoleConfiguration> RoleConfiguration { get; set; }
+        public IEnumerable<ServiceConfiguration> Services { get; set; }
 
         public MultiHostConfiguration()
         {
-            Roles = new RoleConfiguration[0];
+            Services = new ServiceConfiguration[0];
+        }
+
+        public void Validate()
+        {
+            var errors = new List<string>();
+
+            if (CustomRunners != null)
+            {
+                //CustomRunners must be distinct
+                if (CustomRunners.Select(x => x.RunnerName).Distinct(StringComparer.OrdinalIgnoreCase).Count() != CustomRunners.Count())
+                    errors.Add("Multiple Custom Runners with the same identifier");
+            }
+
+            if (RoleConfiguration != null)
+            {
+                //RoleConfigurations must be distinct
+                if (RoleConfiguration.Select(x => x.RoleName).Distinct(StringComparer.OrdinalIgnoreCase).Count() != RoleConfiguration.Count())
+                    errors.Add("Multiple Role Configurations with the same identifier");
+            }
+
+            foreach (var service in Services)
+            {
+                var serviceErrors = service.Validate();
+                errors.AddRange(serviceErrors);
+                //All services with custom RunnerType need a matching runner config
+                if (service.RunnerType == RunnerType.Custom)
+                {
+                    if (CustomRunners == null || !CustomRunners.Any(x => x.RunnerName.Equals(service.RunnerName, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        errors.Add($"Service {service.Title}, Runner {service.RunnerName}, Runner Configuration is Missing");
+                    }
+                }
+                //All Roles in all services need a matching Role Configuration
+                if (RoleConfiguration == null || !RoleConfiguration.Any(x => x.RoleName.Equals(service.RoleName, StringComparison.OrdinalIgnoreCase)))
+                {
+                    errors.Add($"Service {service.Title}, Role {service.RoleName}, Role Configuration is Missing");
+                }
+            }
+
+            if (errors.Any())
+            {
+                var builder = new StringBuilder();
+                builder.AppendLine("Errors:");
+                foreach (var error in errors)
+                    builder.AppendLine(error);
+                throw new ArgumentException($"Host Configured Incorrectly {builder}");
+            }
         }
     }
 }

--- a/LightBlue.MultiHost/Configuration/MultiHostConfigurationService.cs
+++ b/LightBlue.MultiHost/Configuration/MultiHostConfigurationService.cs
@@ -1,5 +1,4 @@
 using System.IO;
-using System.Linq;
 using System.Text.Json;
 
 namespace LightBlue.MultiHost.Configuration
@@ -9,56 +8,23 @@ namespace LightBlue.MultiHost.Configuration
         public MultiHostConfiguration Load(string path)
         {
             var jsonText = File.ReadAllText(path);
-            var configuration = JsonSerializer.Deserialize<MultiHostConfiguration>(jsonText);
+            var configuration = JsonSerializer.Deserialize<MultiHostConfiguration>(jsonText, new JsonSerializerOptions()
+            {
+                AllowTrailingCommas = true,
+                ReadCommentHandling = JsonCommentHandling.Skip
+            });
+
+            configuration.Validate();
 
             return configuration;
         }
 
         public void Save(string path, MultiHostConfiguration multiHostConfiguration)
         {
-            // This model ensures that we don't persist web related configuration into standard (worker) roles
-            var persistanceModel = new
-            {
-                multiHostConfiguration.CustomRunners,
-                multiHostConfiguration.AssemblyCacheId,
-                multiHostConfiguration.ThreadDelayMs,
-                multiHostConfiguration.AppDomainDelayMs,
-                multiHostConfiguration.ProcessDelayMs,
-                Roles = from x in multiHostConfiguration.Roles
-                        let isWorker = string.IsNullOrWhiteSpace(x.Port)
-                        select isWorker
-                            ? (dynamic)new
-                            {
-                                x.EnabledOnStartup,
-                                x.Assembly,
-                                x.RoleName,
-                                x.Title,
-                                x.ConfigurationPath,
-                                
-                                x.RoleIsolationMode,
-                                x.ProcessPriority,
-                            }
-                            : (dynamic)new
-                            {
-                                x.EnabledOnStartup,
-                                x.Assembly,
-                                x.RoleName,
-                                x.Title,
-                                x.ConfigurationPath,
-
-                                x.Port,
-                                x.UseSsl,
-                                x.Hostname,
-
-                                x.RoleIsolationMode,
-                                x.ProcessPriority,
-                            }
-            };
-
             using (var fs = new FileStream(path, FileMode.Truncate, FileAccess.Write))
             using (var sw = new StreamWriter(fs))
             {
-                sw.WriteLine(JsonSerializer.Serialize(persistanceModel, new JsonSerializerOptions { WriteIndented = true, IgnoreNullValues = true }));
+                sw.WriteLine(JsonSerializer.Serialize(multiHostConfiguration, new JsonSerializerOptions { WriteIndented = true, IgnoreNullValues = true }));
             }
         }
     }

--- a/LightBlue.MultiHost/Configuration/RoleConfiguration.cs
+++ b/LightBlue.MultiHost/Configuration/RoleConfiguration.cs
@@ -1,21 +1,11 @@
-﻿namespace LightBlue.MultiHost.Configuration
+﻿using System.Text.Json.Serialization;
+
+namespace LightBlue.MultiHost.Configuration
 {
     public class RoleConfiguration
     {
-        // required by all roles (worker & web)
-        public bool EnabledOnStartup { get; set; }
-        public string Assembly { get; set; }
         public string RoleName { get; set; }
-        public string Title { get; set; }
-        public string ConfigurationPath { get; set; }
-
-        // optional - required for web roles
-        public string Port { get; set; }
-        public string UseSsl { get; set; }
-        public string Hostname { get; set; }
-
-        // optional for all roles
-        public string RoleIsolationMode { get; set; }
-        public string ProcessPriority { get; set; }
+        [JsonConverter(typeof(IconOptionConverter))]
+        public IconOption Icon { get; set; } = IconOption.Worker;
     }
 }

--- a/LightBlue.MultiHost/Configuration/RoleConfigurationService.cs
+++ b/LightBlue.MultiHost/Configuration/RoleConfigurationService.cs
@@ -4,7 +4,7 @@ namespace LightBlue.MultiHost.Configuration
 {
     public class RoleConfigurationService : IRoleConfiguationService
     {
-        public RoleConfiguration Edit(string serviceTitle, string multiHostConfigurationFilePath)
+        public ServiceConfiguration Edit(string serviceTitle, string multiHostConfigurationFilePath)
         {
             var service = new MultiHostConfigurationService();
             var configuration = service.Load(multiHostConfigurationFilePath);

--- a/LightBlue.MultiHost/Configuration/RunnerType.cs
+++ b/LightBlue.MultiHost/Configuration/RunnerType.cs
@@ -1,0 +1,15 @@
+﻿namespace LightBlue.MultiHost.Configuration
+{
+    public enum RunnerType
+    {
+        Unknown,
+        DotNetFramework,
+        DotNetCore,
+        Node,
+        AzureFunction,
+        IisExpress,
+        Thread,
+        AppDomain,
+        Custom
+    }
+}

--- a/LightBlue.MultiHost/Configuration/ServiceConfiguration.cs
+++ b/LightBlue.MultiHost/Configuration/ServiceConfiguration.cs
@@ -1,0 +1,78 @@
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace LightBlue.MultiHost.Configuration
+{
+    public class ServiceConfiguration
+    {
+        // required by all services (worker & web)
+        public bool EnabledOnStartup { get; set; }
+        public string Assembly { get; set; }
+        public string RoleName { get; set; }
+        public string Title { get; set; }
+        public string ConfigurationPath { get; set; }
+
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public RunnerType RunnerType { get; set; }
+
+
+        // optional - required for web roles
+        public string Port { get; set; }
+        public string UseSsl { get; set; }
+        public string Hostname { get; set; }
+
+        // optional for all roles
+        public string ProcessPriority { get; set; }
+
+        //optional - for custom runners
+        public string RunnerName { get; set; }
+
+        public List<string> Validate()
+        {
+            var errors = new List<string>();
+            if (string.IsNullOrWhiteSpace(Assembly))
+                errors.Add("Assembly is missing");
+            if (string.IsNullOrWhiteSpace(RoleName))
+                errors.Add("RoleName is missing");
+            if (string.IsNullOrWhiteSpace(Title))
+                errors.Add("Title is missing");
+            if (string.IsNullOrWhiteSpace(ConfigurationPath))
+                errors.Add("ConfigurationPath is missing");
+            if (RunnerType == RunnerType.Unknown)
+                errors.Add("Unknown RunnerType");
+            //Iis runners need the optionals
+            if (RunnerType == RunnerType.IisExpress)
+            {
+                if (string.IsNullOrWhiteSpace(Port))
+                    errors.Add("Port is missing for IISRunner");
+                if (string.IsNullOrWhiteSpace(UseSsl))
+                    errors.Add("UseSsl is missing for IISRunner");
+                if (string.IsNullOrWhiteSpace(Hostname))
+                    errors.Add("Hostname is missing for IISRunner");
+            }
+            else
+            {
+                if (!string.IsNullOrWhiteSpace(Port))
+                    errors.Add("Port can only be used with IISRunner");
+                if (!string.IsNullOrWhiteSpace(UseSsl))
+                    errors.Add("UseSsl can only be used with IISRunner");
+                if (!string.IsNullOrWhiteSpace(Hostname))
+                    errors.Add("Hostname can only be used with IISRunner");
+            }
+
+            //Custom Runners needs a Runner Name
+            if (RunnerType == RunnerType.Custom)
+            {
+                if (string.IsNullOrWhiteSpace(RunnerName))
+                    errors.Add("RunnerName is missing for CustomRunner");
+            }
+            else
+            {
+                if (!string.IsNullOrWhiteSpace(RunnerName))
+                    errors.Add("RunnerName can only be used with CustomRunner");
+            }
+
+            return errors;
+        }
+    }
+}

--- a/LightBlue.MultiHost/EditRoleView.xaml
+++ b/LightBlue.MultiHost/EditRoleView.xaml
@@ -2,7 +2,8 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:multiHost="clr-namespace:LightBlue.MultiHost"
-        xmlns:enums="clr-namespace:LightBlue.MultiHost.Runners"
+        xmlns:config="clr-namespace:LightBlue.MultiHost.Configuration"
+        xmlns:runners="clr-namespace:LightBlue.MultiHost.Runners"
         Title="Role Configuration" Height="400" Width="800"
         Icon="{Binding MainIcon}">
     <Grid>
@@ -35,7 +36,7 @@
                 <Label Grid.Row="5" Grid.Column="0" Content="Port:"/>
                 <Label Grid.Row="6" Grid.Column="0" Content="UseSsl:"/>
                 <Label Grid.Row="7" Grid.Column="0" Content="Hostname:"/>
-                <Label Grid.Row="8" Grid.Column="0" Content="RoleIsolationMode:"/>
+                <Label Grid.Row="8" Grid.Column="0" Content="Runner Type:"/>
                 <Label Grid.Row="9" Grid.Column="0" Content="ProcessPriority:"/>
 
                 <CheckBox Grid.Row="0" Grid.Column="1" Margin="3"  IsChecked="{Binding RoleConfiguration.EnabledOnStartup}"/>
@@ -58,13 +59,13 @@
 
                 <ComboBox Grid.Row="8" Grid.Column="1" Margin="3" 
                           DisplayMemberPath="DisplayName" 
-                          ItemsSource="{multiHost:EnumToItemsSource {x:Type enums:RoleIsolationMode}}"
-                          SelectedValue="{Binding Path=RoleConfiguration.RoleIsolationMode, Mode=TwoWay}"
+                          ItemsSource="{multiHost:EnumToItemsSource {x:Type config:RunnerType}}"
+                          SelectedValue="{Binding Path=RoleConfiguration.RunnerType, Mode=TwoWay}"
                           SelectedValuePath="Value"/>
 
                 <ComboBox Grid.Row="9" Grid.Column="1" Margin="3" 
                           DisplayMemberPath="DisplayName" 
-                          ItemsSource="{multiHost:EnumToItemsSource {x:Type enums:ProcessPriority}}"
+                          ItemsSource="{multiHost:EnumToItemsSource {x:Type runners:ProcessPriority}}"
                           SelectedValue="{Binding Path=RoleConfiguration.ProcessPriority, Mode=TwoWay}"
                           SelectedValuePath="Value"/>
             </Grid>

--- a/LightBlue.MultiHost/IISExpress/WebConfigHelper.cs
+++ b/LightBlue.MultiHost/IISExpress/WebConfigHelper.cs
@@ -6,7 +6,7 @@ namespace LightBlue.MultiHost.IISExpress
 {
     static class WebConfigHelper
     {
-        public static WebHostArgs Create(RoleConfiguration config)
+        public static WebHostArgs Create(ServiceConfiguration config)
         {
             var assembly = config.Assembly;
             var args = new WebHostArgs

--- a/LightBlue.MultiHost/Runners/AzureFunctionRunner.cs
+++ b/LightBlue.MultiHost/Runners/AzureFunctionRunner.cs
@@ -21,7 +21,7 @@ namespace LightBlue.MultiHost.Runners
 
         public AzureFunctionRunner(Role role)
         {
-            Identifier = role.RoleName;
+            Identifier = "AzureFunction: " + role.RoleName;
 
             _role = role;
         }

--- a/LightBlue.MultiHost/Runners/CustomRunner.cs
+++ b/LightBlue.MultiHost/Runners/CustomRunner.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
+﻿using System.Diagnostics;
 using System.Threading.Tasks;
 using LightBlue.MultiHost.Configuration;
 using LightBlue.MultiHost.ViewModel;
@@ -23,12 +20,12 @@ namespace LightBlue.MultiHost.Runners
 
         private readonly CustomRunnerConfiguration _config;
 
-        public CustomRunner(CustomRunnerConfiguration config, Role role)
+        public CustomRunner(Role role)
         {
-            Identifier = role.RoleName;
+            Identifier = $"{role.CustomRunnerConfiguration.RunnerName}: {role.RoleName}";
 
             _role = role;
-            _config = config;
+            _config = role.CustomRunnerConfiguration;
         }
 
         public void Start()

--- a/LightBlue.MultiHost/Runners/DotNetCoreRunner.cs
+++ b/LightBlue.MultiHost/Runners/DotNetCoreRunner.cs
@@ -8,9 +8,7 @@ namespace LightBlue.MultiHost.Runners
     {
         private readonly Role _role;
         private Process _parent;
-
         public string Identifier { get; }
-
         public Task Started => _started.Task;
         public Task Completed => _completed.Task;
 
@@ -19,7 +17,7 @@ namespace LightBlue.MultiHost.Runners
 
         public DotNetCoreRunner(Role role)
         {
-            Identifier = role.RoleName;
+            Identifier = "Dotnet: " + role.RoleName;
 
             _role = role;
         }

--- a/LightBlue.MultiHost/Runners/DotNetFrameworkRunner.cs
+++ b/LightBlue.MultiHost/Runners/DotNetFrameworkRunner.cs
@@ -19,7 +19,7 @@ namespace LightBlue.MultiHost.Runners
 
         public DotNetFrameworkRunner(Role role)
         {
-            Identifier = role.RoleName;
+            Identifier = ".NET Framework: " + role.RoleName;
 
             _role = role;
         }

--- a/LightBlue.MultiHost/Runners/NpmRunner.cs
+++ b/LightBlue.MultiHost/Runners/NpmRunner.cs
@@ -22,7 +22,7 @@ namespace LightBlue.MultiHost.Runners
 
         public NpmRunner(Role role)
         {
-            Identifier = role.RoleName;
+            Identifier = "Node: " + role.RoleName;
 
             _role = role;
         }

--- a/LightBlue.MultiHost/Runners/RoleIsolationMode.cs
+++ b/LightBlue.MultiHost/Runners/RoleIsolationMode.cs
@@ -1,9 +1,0 @@
-namespace LightBlue.MultiHost.Runners
-{
-    public enum RoleIsolationMode
-    {
-        Thread,
-        AppDomain,
-        Process
-    }
-}

--- a/LightBlue.MultiHost/ViewModel/CustomBrushes.cs
+++ b/LightBlue.MultiHost/ViewModel/CustomBrushes.cs
@@ -1,5 +1,5 @@
 ﻿using System.Windows.Media;
-using LightBlue.MultiHost.Runners;
+using LightBlue.MultiHost.Configuration;
 
 namespace LightBlue.MultiHost.ViewModel
 {
@@ -11,16 +11,16 @@ namespace LightBlue.MultiHost.ViewModel
         public static SolidColorBrush Blue = Brushes.SteelBlue;
         public static SolidColorBrush Main = Brushes.DodgerBlue;
 
-        public static SolidColorBrush GetStatusColour(RoleStatus status, RoleIsolationMode isolationMode)
+        public static SolidColorBrush GetStatusColour(RoleStatus status, RunnerType runnerType)
         {
             switch (status)
             {
                 case RoleStatus.Starting:
-                    return isolationMode == RoleIsolationMode.Thread
+                    return runnerType == RunnerType.Thread
                         ? Green
                         : Blue;
                 case RoleStatus.Running:
-                    return isolationMode == RoleIsolationMode.Thread
+                    return runnerType == RunnerType.Thread
                         ? Green
                         : Blue;
                 case RoleStatus.Stopping:

--- a/LightBlue.MultiHost/ViewModel/EditRole.cs
+++ b/LightBlue.MultiHost/ViewModel/EditRole.cs
@@ -10,7 +10,7 @@ namespace LightBlue.MultiHost.ViewModel
         private readonly string _serviceTitle;
         private readonly MultiHostConfiguration _multiHostConfiguration;
         private readonly string _multiHostConfigurationFilePath;
-        private RoleConfiguration _roleConfiguration;
+        private ServiceConfiguration _roleConfiguration;
 
         public EditRole(string serviceTitle, MultiHostConfiguration multiHostConfiguration, string multiHostConfigurationFilePath)
         {
@@ -18,12 +18,12 @@ namespace LightBlue.MultiHost.ViewModel
             _multiHostConfiguration = multiHostConfiguration;
             _multiHostConfigurationFilePath = multiHostConfigurationFilePath;
 
-            RoleConfiguration = _multiHostConfiguration.Roles.Single(x => x.Title == _serviceTitle);
+            RoleConfiguration = _multiHostConfiguration.Services.Single(x => x.Title == _serviceTitle);
         }
 
         public ImageSource MainIcon { get { return ImageUtil.ColourImage(@"Resources\debug.ico", CustomBrushes.Main); } }
 
-        public RoleConfiguration RoleConfiguration
+        public ServiceConfiguration RoleConfiguration
         {
             get { return _roleConfiguration; }
             set

--- a/LightBlue/ConfigurationLocator.cs
+++ b/LightBlue/ConfigurationLocator.cs
@@ -25,7 +25,7 @@ namespace LightBlue
             if (!File.Exists(configurationFile))
             {
                 throw new ArgumentException(
-                    "ServiceConfiguration.Local.cscfg cannot be located in the configuration path.");
+                    $"ServiceConfiguration.Local.cscfg cannot be located in the configuration path. {configurationFile}");
             }
 
             return configurationFile;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 image: Visual Studio 2022
-version: 4.0.{build}.0  # check assembly_version adn file_version below when changing
+version: 5.0.{build}.0  # check assembly_version adn file_version below when changing
 pull_requests:
   do_not_increment_build_number: true
 configuration: Release
@@ -9,8 +9,8 @@ dotnet_csproj:
   file: '**\*.csproj'
   version: '{version}'
   package_version: '{version}'
-  assembly_version: '4.0.{build}.0'
-  file_version: '4.0.{build}.0'
+  assembly_version: '5.0.{build}.0'
+  file_version: '5.0.{build}.0'
   informational_version: '{version}'
 nuget:
   account_feed: true


### PR DESCRIPTION
- split the role and runner concerns in config
- add in role configuration, give icon responsibility
- rename previous role configuration to service configuration
- replace role-type delay with start up rate limit
- make custom runner concept a more explicit choice
- add config validation to help users
- reduce complexity of config save