### PR TITLE
Load Environment variables into ConfigurationManager.AppSettings

### DIFF
--- a/LightBlue.Tests/Setup/LightBlueConfigurationTests.cs
+++ b/LightBlue.Tests/Setup/LightBlueConfigurationTests.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Configuration;
+using System.Reflection;
+using LightBlue.Setup;
+using Xunit;
+
+namespace LightBlue.Tests.Setup
+{
+    public class LightBlueConfigurationTests : IDisposable
+    {
+        private readonly string[] _environmentVariablesToCleanup;
+
+        public LightBlueConfigurationTests()
+        {
+            // Track environment variables we set during tests for cleanup
+            _environmentVariablesToCleanup = new[]
+            {
+                "TestKey1",
+                "TestKey2", 
+                "ExistingKey",
+                "IntegrationTestKey1",
+                "IntegrationTestKey2",
+            };
+        }
+
+        public void Dispose()
+        {
+            // Clean up environment variables after each test
+            foreach (var envVar in _environmentVariablesToCleanup)
+            {
+                Environment.SetEnvironmentVariable(envVar, null);
+
+                // We only have ExistingKey in app.config, reset to just that
+                ConfigurationManager.RefreshSection("appSettings");
+            }
+            
+            // Reset LightBlueConfiguration context to null using reflection
+            var contextField = typeof(LightBlueConfiguration).GetField("_context", 
+                BindingFlags.NonPublic | BindingFlags.Static);
+            contextField?.SetValue(null, null);
+        }
+
+        [Fact]
+        public void LoadAzureEnvironmentSettings_MethodCanBeInvokedWithoutException()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("TestKey1", "TestValue1");
+            Environment.SetEnvironmentVariable("TestKey2", "TestValue2");
+
+            // Act
+            var exception = Record.Exception(() => LightBlueConfiguration.GetConfiguredContext());
+
+            // Assert
+            Assert.Null(exception); // Method should execute without throwing
+        }
+
+        [Fact]
+        public void LoadAzureEnvironmentSettings_ProcessesEnvironmentVariablesCorrectly()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("TestKey1", "TestValue1");
+            ILightBlueContext context = null;
+            
+            // Act
+            var exception = Record.Exception(() => context = LightBlueConfiguration.GetConfiguredContext());
+            
+            // Assert
+            Assert.Null(exception); // Method should execute without throwing
+            Assert.Equal("TestValue1", context.Settings["TestKey1"]);
+        }
+
+        [Fact]
+        public void LoadAzureEnvironmentSettings_HandlesEmptyEnvironmentVariables()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("TestKey1", "");
+            ILightBlueContext context = null;
+
+            // Act
+            var exception = Record.Exception(() => context = LightBlueConfiguration.GetConfiguredContext());
+
+            // Assert
+            Assert.Null(exception); // Method should execute without throwing
+            Assert.Null(context.Settings["TestKey1"]);
+        }
+
+        [Fact]
+        public void LoadAzureEnvironmentSettings_HandlesNullEnvironmentVariables()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("TestKey1", "SomeValue");
+            Environment.SetEnvironmentVariable("TestKey1", null); // Remove it
+            ILightBlueContext context = null;
+
+            // Act
+            var exception = Record.Exception(() => context = LightBlueConfiguration.GetConfiguredContext());
+
+            // Assert
+            Assert.Null(exception); // Method should execute without throwing
+            Assert.Null(context.Settings["TestKey1"]);
+        }
+
+        [Fact]
+        public void LoadAzureEnvironmentSettings_IntegrationTest()
+        {
+            // Arrange
+            ILightBlueContext context = null;
+            var testEnvironmentVariables = new[]
+            {
+                ("ExistingKey", "NewValue"),
+                ("IntegrationTestKey1", "IntegrationTestValue1"),
+                ("IntegrationTestKey2", "Special!@#$%Characters"),
+            };
+
+            // ConfigurationManager.AppSettings already have ExistingKey from the app.config file
+            Assert.Equal("ExistingValue", ConfigurationManager.AppSettings["ExistingKey"]);
+
+            // Set up test environment variables
+            foreach (var (key, value) in testEnvironmentVariables)
+            {
+                Environment.SetEnvironmentVariable(key, value);
+            }
+
+            // Act
+            var exception = Record.Exception(() => context = LightBlueConfiguration.GetConfiguredContext());
+
+            // Assert
+            Assert.Null(exception); // Method should execute without throwing
+
+            // Verify environment variables are still accessible (they weren't corrupted)
+            foreach (var (key, value) in testEnvironmentVariables)
+            {
+                Assert.Equal(value, Environment.GetEnvironmentVariable(key));
+            }
+
+            // Verify that the context settings reflect the environment variables
+            foreach (var (key, value) in testEnvironmentVariables)
+            {
+                Assert.Equal(value, context.Settings[key]);
+            }
+        }
+    }
+}

--- a/LightBlue.Tests/app.config
+++ b/LightBlue.Tests/app.config
@@ -8,6 +8,7 @@
     <add key="Configuration" value="C:\Source\LightBlue\TestCloudService"/>
     <add key="UseSSL" value="true"/>
     <add key="Host" value="localhost"/>
+    <add key="ExistingKey" value="ExistingValue"/>
   </appSettings>
   <runtime>
   </runtime>

--- a/LightBlue/Properties/AssemblyInfo.cs
+++ b/LightBlue/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -9,3 +8,4 @@ using System.Runtime.InteropServices;
 
 [assembly: CLSCompliant(false)]
 [assembly: InternalsVisibleTo("LightBlue.Testability")]
+[assembly: InternalsVisibleTo("LightBlue.Tests")]

--- a/LightBlue/Setup/LightBlueConfiguration.cs
+++ b/LightBlue/Setup/LightBlueConfiguration.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Configuration;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -106,6 +107,8 @@ namespace LightBlue.Setup
 
         private static void LoadDefinitionFromEnvironmentVariablesOrAzureRoleDefinition()
         {
+            LoadAzureEnvironmentSettings();
+
             if (HasLightBlueEnvironmentFlag())
             {
                 SetAsLightBlue(
@@ -139,6 +142,23 @@ namespace LightBlue.Setup
             }
 
             return isInLightBlueHost;
+        }
+
+        /// <summary>
+        /// Loads all environment variables into the application's configuration settings.
+        /// </summary>
+        /// <remarks>This method copies each environment variable into the application's configuration by
+        /// setting the corresponding value in <see cref="ConfigurationManager.AppSettings"/>. Existing keys in <see
+        /// cref="ConfigurationManager.AppSettings"/> will be overwritten if they match an environment variable name.
+        /// This method does not return a value and is intended for internal use during application startup or
+        /// configuration initialization.</remarks>
+        private static void LoadAzureEnvironmentSettings()
+        {
+            foreach (var key in Environment.GetEnvironmentVariables().Keys)
+            {
+                var value = Environment.GetEnvironmentVariable(key.ToString());
+                ConfigurationManager.AppSettings.Set(key.ToString(), value);
+            }
         }
     }
 }


### PR DESCRIPTION
- In net48, Azure automatically loads environment variables into ConfigurationManager.AppSettings for a hosted service (like a webjob)
- In net8, Azure automatically loads environment variables into IConfiguration for a hosted service (like a webjob)
- LightBlue does not support IConfiguration at this time. This is a medium term fix to automatically load environment variables into ConfigurationManager.AppSettings for all versions of dotnet and regardless of Azure hosting